### PR TITLE
Fix: match-operator lazy evaluation causing "callback is not a function" error

### DIFF
--- a/app/composables/useTask.ts
+++ b/app/composables/useTask.ts
@@ -48,13 +48,12 @@ export const useTask = () => {
       if (task.error) {
         task.error = new TaskError(task.error.message, task.error.code, task.error.type, task.error.link)
       }
-      const callback = match(task.status, [
-        ['succeeded', onSuccess],
-        ['canceled', onCanceled],
-        ['failed', onFailure],
+      match(task.status, [
+        ['succeeded', () => onSuccess(task)],
+        ['canceled', () => onCanceled(task)],
+        ['failed', () => onFailure(task)],
         [match.default, () => console.debug('Unhandled match for task', task)],
       ])
-      callback(task)
       return task
     } catch (e) {
       if (e instanceof MeiliSearchRequestTimeOutError) {


### PR DESCRIPTION
## Summary

- `match-operator` auto-invokes functions used as match values ("lazy expressions"), returning `void` instead of the function itself
- This caused `callback` to be `undefined` after the `match()` call, making `callback(task)` throw `TypeError: callback is not a function`
- Fix: wrap each callback so `match` calls them directly with `task` via closure

## Root cause

```ts
// Before — match calls onSuccess(task.status) immediately, callback = undefined
const callback = match(task.status, [
  ['succeeded', onSuccess],
  ...
])
callback(task) // 💥 TypeError: callback is not a function

// After — match calls the wrapper, which calls onSuccess(task) via closure
match(task.status, [
  ['succeeded', () => onSuccess(task)],
  ...
])
```

## Test plan

- [ ] Navigate to a settings page (searchable attributes, filterable attributes, etc.)
- [ ] Submit the form
- [ ] Verify no error banner appears after a successful update

🤖 Generated with [Claude Code](https://claude.com/claude-code)