### PR TITLE
Feat: add/remove custom ranking rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ Stop and wipe: `kill $MEILI_PID && rm -rf /tmp/meiliweb-test-meili`
 Datasets from https://github.com/meilisearch/datasets — download via `gh api` to avoid rate limits.
 
 **movies** (32 K docs, 19 MB) — canonical Meilisearch demo; rich for search/filter/sort/facet testing:
+
 ```bash
 gh api repos/meilisearch/datasets/contents/datasets/movies/movies.json --jq '.download_url' \
   | xargs curl -s \
@@ -270,6 +271,7 @@ curl -sX PATCH http://127.0.0.1:7700/indexes/movies/settings \
 ```
 
 **books** (244 docs, 94 KB) — fast to index; good for nested objects and quick iteration:
+
 ```bash
 gh api repos/meilisearch/datasets/contents/datasets/books/books.json --jq '.download_url' \
   | xargs curl -s \
@@ -279,6 +281,7 @@ gh api repos/meilisearch/datasets/contents/datasets/books/books.json --jq '.down
 ```
 
 **restaurants** (200 docs, 178 KB, with bundled `settings.json`) — ready-made for filter/facet/category testing:
+
 ```bash
 gh api repos/meilisearch/datasets/contents/datasets/restaurants/restaurants.json --jq '.download_url' \
   | xargs curl -s \
@@ -294,6 +297,7 @@ gh api repos/meilisearch/datasets/contents/datasets/restaurants/settings.json --
 ```
 
 Wait for all indexing tasks to finish before testing the UI:
+
 ```bash
 until [ "$(curl -s 'http://127.0.0.1:7700/tasks?statuses=enqueued,processing' \
   -H 'Authorization: Bearer meiliweb-dev-masterkey' | python3 -c 'import json,sys; print(json.load(sys.stdin)["total"])')" = "0" ]; do sleep 1; done
@@ -328,12 +332,28 @@ browser_take_screenshot → verify visually
 ```
 
 Example fill_form call (after snapshot, adapt `target` refs):
+
 ```json
 {
   "fields": [
-    { "target": "input[placeholder='http://localhost:7700']", "name": "Instance URL",    "type": "textbox", "value": "http://127.0.0.1:7700" },
-    { "target": "input[type='password']",                    "name": "Access Token",    "type": "textbox", "value": "meiliweb-dev-masterkey" },
-    { "target": "input[placeholder='Local instance']",       "name": "Instance Name",   "type": "textbox", "value": "Dev instance" }
+    {
+      "target": "input[placeholder='http://localhost:7700']",
+      "name": "Instance URL",
+      "type": "textbox",
+      "value": "http://127.0.0.1:7700"
+    },
+    {
+      "target": "input[type='password']",
+      "name": "Access Token",
+      "type": "textbox",
+      "value": "meiliweb-dev-masterkey"
+    },
+    {
+      "target": "input[placeholder='Local instance']",
+      "name": "Instance Name",
+      "type": "textbox",
+      "value": "Dev instance"
+    }
   ]
 }
 ```

--- a/app/pages/indexes/[indexUid]/settings/ranking-rules.vue
+++ b/app/pages/indexes/[indexUid]/settings/ranking-rules.vue
@@ -52,16 +52,16 @@
     </section>
 
     <div class="flex items-center gap-2">
-      <select v-model="newRuleDirection" class="form-input shrink-0 text-sm">
-        <option value="asc">↑ asc</option>
-        <option value="desc">↓ desc</option>
-      </select>
       <input
         v-model="newRuleField"
         type="text"
         class="form-input flex-1 text-sm"
         :placeholder="t('placeholders.fieldName')"
         @keydown.enter.prevent="addCustomRule()" />
+      <select v-model="newRuleDirection" class="form-input shrink-0 text-sm">
+        <option value="asc">↑ asc</option>
+        <option value="desc">↓ desc</option>
+      </select>
       <Button
         type="button"
         theme="secondary"

--- a/app/pages/indexes/[indexUid]/settings/ranking-rules.vue
+++ b/app/pages/indexes/[indexUid]/settings/ranking-rules.vue
@@ -12,17 +12,66 @@
 
     <section v-sortable class="space-y-2" @end="onOrderChange">
       <div
-        v-for="rankingRule of initialRankingRules"
-        :key="rankingRule"
+        v-for="(rankingRule, i) of self.rankingRules"
+        :key="i"
         role="treeitem"
         class="flex cursor-move items-center justify-between gap-2 rounded-md border border-gray-100 px-2 py-1.5 text-sm text-gray-800 shadow-sm">
-        <dl>
-          <dt class="font-medium capitalize">{{ rankingRule }}</dt>
-          <dd class="text-xs italic text-gray-600">{{ t(`descriptions.${rankingRule}`) }}</dd>
+        <dl class="flex-1 overflow-hidden">
+          <template v-if="isBuiltIn(rankingRule)">
+            <dt class="font-medium capitalize">{{ rankingRule }}</dt>
+            <dd class="text-xs italic text-gray-600">{{ t(`descriptions.${rankingRule}`) }}</dd>
+          </template>
+          <template v-else>
+            <dt class="flex items-center gap-1.5 font-medium">
+              <span
+                class="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-xs font-semibold"
+                :class="
+                  parseCustomRule(rankingRule)?.direction === 'asc'
+                    ? 'bg-blue-100 text-blue-700'
+                    : 'bg-orange-100 text-orange-700'
+                ">
+                {{ parseCustomRule(rankingRule)?.direction === 'asc' ? '↑ asc' : '↓ desc' }}
+              </span>
+              <span class="truncate">{{ parseCustomRule(rankingRule)?.field }}</span>
+            </dt>
+            <dd class="text-xs italic text-gray-600">{{ t('descriptions.custom') }}</dd>
+          </template>
         </dl>
-        <Icon name="uil:draggabledots" />
+        <div class="flex shrink-0 items-center gap-1">
+          <button
+            v-if="!isBuiltIn(rankingRule)"
+            type="button"
+            class="text-gray-400 transition-colors hover:text-red-500"
+            :title="t('actions.removeRule')"
+            @click="removeRule(i)">
+            <Icon name="mdi:close" />
+          </button>
+          <Icon name="uil:draggabledots" />
+        </div>
       </div>
     </section>
+
+    <div class="flex items-center gap-2">
+      <select v-model="newRuleDirection" class="form-input shrink-0 text-sm">
+        <option value="asc">↑ asc</option>
+        <option value="desc">↓ desc</option>
+      </select>
+      <input
+        v-model="newRuleField"
+        type="text"
+        class="form-input flex-1 text-sm"
+        :placeholder="t('placeholders.fieldName')"
+        @keydown.enter.prevent="addCustomRule()" />
+      <Button
+        type="button"
+        theme="secondary"
+        icon="mdi:plus"
+        size="small"
+        :disabled="!newRuleField.trim()"
+        @click="addCustomRule()">
+        {{ t('actions.addRule') }}
+      </Button>
+    </div>
 
     <footer class="flex flex-col items-center justify-between sm:flex-row">
       <Button
@@ -58,6 +107,18 @@ type Props = {
 }
 const props = defineProps<Props>()
 
+const BUILT_IN_RULES = ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness']
+
+function isBuiltIn(rule: string): boolean {
+  return BUILT_IN_RULES.includes(rule)
+}
+
+function parseCustomRule(rule: string): { direction: 'asc' | 'desc'; field: string } | null {
+  const m = rule.match(/^(.+):(asc|desc)$/)
+  if (!m) return null
+  return { field: m[1]!, direction: m[2] as 'asc' | 'desc' }
+}
+
 const { t } = useI18n()
 const meili = useMeiliClient()
 const index = meili.index(props.indexUid)
@@ -69,13 +130,25 @@ const { createToast } = useToasts()
 const { confirm } = useConfirmationDialog()
 const initialRankingRules = await index.getRankingRules()
 const { value: rankingRules, reset, modified } = resettableRef([...initialRankingRules])
-const self = reactive({
-  rankingRules,
-})
+const self = reactive({ rankingRules })
+
+const newRuleDirection = ref<'asc' | 'desc'>('asc')
+const newRuleField = ref('')
 
 function onOrderChange(event: Event & { oldIndex: number; newIndex: number }) {
-  let item = self.rankingRules.splice(event.oldIndex, 1)[0]
+  const item = self.rankingRules.splice(event.oldIndex, 1)[0]
   self.rankingRules.splice(event.newIndex, 0, item!)
+}
+
+function addCustomRule() {
+  const field = newRuleField.value.trim()
+  if (!field) return
+  self.rankingRules.push(`${field}:${newRuleDirection.value}`)
+  newRuleField.value = ''
+}
+
+function removeRule(i: number) {
+  self.rankingRules.splice(i, 1)
 }
 
 const submit = async () => {
@@ -107,6 +180,7 @@ const submit = async () => {
     reset(self.rankingRules)
   })
 }
+
 const resetToInitialValue = async () => {
   if (!(await confirm({ text: t('confirmations.reset') }))) {
     return
@@ -141,7 +215,7 @@ const resetToInitialValue = async () => {
 <i18n>
 en:
   title: Ranking Rules
-  description: Ranking rules are built-in rules that rank search results according to certain criteria. They are applied in the same order in which they appear below. Drag-and-drop to reorder.
+  description: Rules applied in order to rank search results. Built-in rules cannot be removed. Drag-and-drop to reorder, and add custom rules based on document attributes.
   toasts:
     updateRankingRules:
       title: Updating Ranking Rules...
@@ -157,4 +231,12 @@ en:
     attribute: Sorts results based on the attribute ranking order.
     sort: Sorts results based on parameters decided at query time.
     exactness: Sorts results based on the similarity of the matched words with the query words.
+    custom: Custom ranking rule — sorts results by the value of this attribute.
+  placeholders:
+    fieldName: "e.g. price or publication_year"
+  actions:
+    addRule: Add rule
+    removeRule: Remove rule
+  buttons:
+    reset: Reset to defaults
 </i18n>

--- a/app/pages/indexes/[indexUid]/settings/ranking-rules.vue
+++ b/app/pages/indexes/[indexUid]/settings/ranking-rules.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="space-y-4" @reset.prevent="reset()" @submit.prevent="submit()">
+  <form class="space-y-4" @reset.prevent="handleReset()" @submit.prevent="submit()">
     <h3 class="inline-flex w-full items-start justify-between">
       <span class="inline-flex flex-col gap-1">
         <span class="text-xl font-semibold">{{ t('title') }}</span>
@@ -10,40 +10,40 @@
       <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/settings#ranking-rules" />
     </h3>
 
-    <section v-sortable class="space-y-2" @end="onOrderChange">
+    <section :key="rerenderKey" v-sortable class="space-y-2" @end="onOrderChange">
       <div
-        v-for="(rankingRule, i) of self.rankingRules"
-        :key="i"
+        v-for="rule in displayList"
+        :key="rule"
         role="treeitem"
         class="flex cursor-move items-center justify-between gap-2 rounded-md border border-gray-100 px-2 py-1.5 text-sm text-gray-800 shadow-sm">
         <dl class="flex-1 overflow-hidden">
-          <template v-if="isBuiltIn(rankingRule)">
-            <dt class="font-medium capitalize">{{ rankingRule }}</dt>
-            <dd class="text-xs italic text-gray-600">{{ t(`descriptions.${rankingRule}`) }}</dd>
+          <template v-if="isBuiltIn(rule)">
+            <dt class="font-medium capitalize">{{ rule }}</dt>
+            <dd class="text-xs italic text-gray-600">{{ t(`descriptions.${rule}`) }}</dd>
           </template>
           <template v-else>
             <dt class="flex items-center gap-1.5 font-medium">
               <span
                 class="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-xs font-semibold"
                 :class="
-                  parseCustomRule(rankingRule)?.direction === 'asc'
+                  parseCustomRule(rule)?.direction === 'asc'
                     ? 'bg-blue-100 text-blue-700'
                     : 'bg-orange-100 text-orange-700'
                 ">
-                {{ parseCustomRule(rankingRule)?.direction === 'asc' ? '↑ asc' : '↓ desc' }}
+                {{ parseCustomRule(rule)?.direction === 'asc' ? '↑ asc' : '↓ desc' }}
               </span>
-              <span class="truncate">{{ parseCustomRule(rankingRule)?.field }}</span>
+              <span class="truncate">{{ parseCustomRule(rule)?.field }}</span>
             </dt>
             <dd class="text-xs italic text-gray-600">{{ t('descriptions.custom') }}</dd>
           </template>
         </dl>
         <div class="flex shrink-0 items-center gap-1">
           <button
-            v-if="!isBuiltIn(rankingRule)"
+            v-if="!isBuiltIn(rule)"
             type="button"
             class="text-gray-400 transition-colors hover:text-red-500"
             :title="t('actions.removeRule')"
-            @click="removeRule(i)">
+            @click="removeRule(rule)">
             <Icon name="mdi:close" />
           </button>
           <Icon name="uil:draggabledots" />
@@ -132,12 +132,24 @@ const initialRankingRules = await index.getRankingRules()
 const { value: rankingRules, reset, modified } = resettableRef([...initialRankingRules])
 const self = reactive({ rankingRules })
 
+// Separate display list: only updated on add/remove (not on drag-and-drop reorder).
+// This prevents Vue from re-rendering during a drag and conflicting with Sortable's DOM manipulation.
+const displayList = ref([...initialRankingRules])
+// Bumping this key force-remounts the <section>, reinitializing Sortable with the fresh DOM.
+const rerenderKey = ref(0)
+
+function syncDisplay() {
+  displayList.value = [...self.rankingRules]
+  rerenderKey.value++
+}
+
 const newRuleDirection = ref<'asc' | 'desc'>('asc')
 const newRuleField = ref('')
 
 function onOrderChange(event: Event & { oldIndex: number; newIndex: number }) {
   const item = self.rankingRules.splice(event.oldIndex, 1)[0]
   self.rankingRules.splice(event.newIndex, 0, item!)
+  // Intentionally NOT calling syncDisplay() — Sortable owns the DOM for reorders.
 }
 
 function addCustomRule() {
@@ -145,10 +157,18 @@ function addCustomRule() {
   if (!field) return
   self.rankingRules.push(`${field}:${newRuleDirection.value}`)
   newRuleField.value = ''
+  syncDisplay()
 }
 
-function removeRule(i: number) {
-  self.rankingRules.splice(i, 1)
+function removeRule(rule: string) {
+  const idx = self.rankingRules.indexOf(rule)
+  if (idx !== -1) self.rankingRules.splice(idx, 1)
+  syncDisplay()
+}
+
+function handleReset() {
+  reset()
+  syncDisplay()
 }
 
 const submit = async () => {
@@ -163,6 +183,7 @@ const submit = async () => {
       onSuccess: async () => {
         toast.update({ ...TOAST_SUCCESS(t) })
         reset(self.rankingRules)
+        syncDisplay()
       },
       onCanceled: () =>
         toast.update({
@@ -194,7 +215,9 @@ const resetToInitialValue = async () => {
   await processTask(() => index.resetRankingRules(), {
     onSuccess: async () => {
       toast.update({ ...TOAST_SUCCESS(t) })
-      reset(await index.getRankingRules())
+      const freshRules = await index.getRankingRules()
+      reset(freshRules)
+      syncDisplay()
     },
     onCanceled: () =>
       toast.update({


### PR DESCRIPTION
## Summary

- Add the ability to create custom ranking rules (`field:asc` / `field:desc`) directly in the Ranking Rules settings page
- Add the ability to delete custom ranking rules (built-in rules remain non-deletable)
- Reordering via drag-and-drop now works for all rules — built-in and custom alike
- Custom rules are displayed with a direction badge (blue `↑ asc` / orange `↓ desc`) and the field name
- The `v-for` now iterates over the reactive `self.rankingRules` array (previously `initialRankingRules`) so additions and deletions render immediately

**Note on API format:** Meilisearch 1.x uses `field:asc` / `field:desc` syntax (not the older `asc(field)` / `desc(field)` format documented in some older resources).

## Test plan

- [ ] Navigate to an index → Settings → Ranking Rules
- [ ] Verify the 6 built-in rules display with descriptions and no delete button
- [ ] Add a custom rule (`asc` direction, any field name) → confirm it appears with blue `↑ asc` badge and `×` button
- [ ] Add a `desc` custom rule → confirm orange `↓ desc` badge
- [ ] Drag-and-drop to reorder — verify both built-in and custom rules can be reordered
- [ ] Click `×` on a custom rule — verify it is removed
- [ ] Submit → confirm toast succeeds and `Submit` button becomes disabled
- [ ] Reload page — verify saved custom rules are loaded and rendered correctly
- [ ] Click "Reset to defaults" → confirm custom rules are wiped and built-in defaults restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)