### PR TITLE
Feat: network topology management UI

### DIFF
--- a/app/components/layout/TopNavigation.vue
+++ b/app/components/layout/TopNavigation.vue
@@ -193,6 +193,11 @@ const navigation = reactive([
     current: computed(() => route.name?.startsWith('tasks')),
   },
   {
+    name: 'Network',
+    href: '/network',
+    current: computed(() => route.name?.startsWith('network')),
+  },
+  {
     name: 'Dumps',
     href: '/dumps',
     current: computed(() => route.name?.startsWith('dumps')),

--- a/app/components/network/RemoteEditorModal.vue
+++ b/app/components/network/RemoteEditorModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <PromisifiedDialog :title="remote ? t('title.edit') : t('title.create')" v-slot="{ resolve, close }">
+    <form class="space-y-4" @submit.prevent="resolve(payload())" @reset.prevent="close()">
+      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
+        <Label required :for="id">{{ t('labels.name') }}</Label>
+        <input
+          :id
+          v-model.trim="form.name"
+          required
+          v-focus
+          :disabled="!!remote"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          type="text"
+          :placeholder="t('placeholders.name')"
+          class="form-input disabled:cursor-not-allowed disabled:bg-gray-100" />
+      </UniqueId>
+
+      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
+        <Label required :for="id">{{ t('labels.url') }}</Label>
+        <input
+          :id
+          v-model.trim="form.url"
+          required
+          type="url"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          :placeholder="t('placeholders.url')"
+          class="form-input" />
+      </UniqueId>
+
+      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.searchApiKey') }}</Label>
+        <input
+          :id
+          v-model="form.searchApiKey"
+          type="text"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          :placeholder="t('placeholders.optional')"
+          class="form-input" />
+      </UniqueId>
+
+      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.writeApiKey') }}</Label>
+        <input
+          :id
+          v-model="form.writeApiKey"
+          type="text"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          :placeholder="t('placeholders.optional')"
+          class="form-input" />
+      </UniqueId>
+
+      <Buttons>
+        <Button type="reset" />
+        <Button type="submit" />
+      </Buttons>
+    </form>
+  </PromisifiedDialog>
+</template>
+
+<script setup lang="ts">
+import PromisifiedDialog from '~/components/layout/dialogs/PromisifiedDialog.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import type { Remote } from '~/components/network/types'
+
+type RemoteEntry = { name: string } & Remote
+
+type Props = {
+  /** Existing remote to edit (name read-only), or `null`/`undefined` to create a new one. */
+  remote?: RemoteEntry | null
+  /** Remote names already in use, to prevent duplicates when creating. */
+  existingNames?: string[]
+}
+const props = defineProps<Props>()
+const { t } = useI18n()
+
+const form = reactive({
+  name: props.remote?.name ?? '',
+  url: props.remote?.url ?? '',
+  searchApiKey: props.remote?.searchApiKey ?? '',
+  writeApiKey: props.remote?.writeApiKey ?? '',
+})
+
+// The promise resolves with a normalized entry; empty optional keys become null (PATCH clears them).
+const payload = (): RemoteEntry => ({
+  name: form.name,
+  url: form.url,
+  searchApiKey: form.searchApiKey.trim() || null,
+  writeApiKey: form.writeApiKey.trim() || null,
+})
+</script>
+
+<i18n>
+en:
+  title:
+    create: Add remote
+    edit: Edit remote
+  labels:
+    name: Name
+    url: URL
+    searchApiKey: Search API key
+    writeApiKey: Write API key
+  placeholders:
+    name: ms-1
+    url: http://localhost:7701
+    optional: Optional
+</i18n>

--- a/app/components/network/ShardEditorModal.vue
+++ b/app/components/network/ShardEditorModal.vue
@@ -1,0 +1,77 @@
+<template>
+  <PromisifiedDialog :title="shardName ? t('title.edit') : t('title.create')" v-slot="{ resolve, close }">
+    <form class="space-y-4" @submit.prevent="resolve(payload())" @reset.prevent="close()">
+      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
+        <Label required :for="id">{{ t('labels.name') }}</Label>
+        <input
+          :id
+          v-model.trim="form.name"
+          required
+          v-focus
+          :disabled="!!shardName"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          type="text"
+          :placeholder="t('placeholders.name')"
+          class="form-input disabled:cursor-not-allowed disabled:bg-gray-100" />
+      </UniqueId>
+
+      <section class="flex flex-col gap-1">
+        <Label>{{ t('labels.remotes') }}</Label>
+        <p class="text-sm font-light text-gray-600">{{ t('hints.remotes') }}</p>
+        <MultiCombobox v-model="form.remotes" :items="remoteNames" auto-hide>
+          <template #empty-state>
+            <span class="text-gray-400">{{ t('placeholders.remotes') }}</span>
+          </template>
+        </MultiCombobox>
+      </section>
+
+      <Buttons>
+        <Button type="reset" />
+        <Button type="submit" />
+      </Buttons>
+    </form>
+  </PromisifiedDialog>
+</template>
+
+<script setup lang="ts">
+import PromisifiedDialog from '~/components/layout/dialogs/PromisifiedDialog.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import MultiCombobox from '~/components/layout/forms/MultiCombobox.vue'
+
+type Props = {
+  /** Existing shard name to edit (read-only), or `null`/`undefined` to create a new one. */
+  shardName?: string | null
+  /** Remotes currently assigned to the shard being edited. */
+  remotes?: string[]
+  /** All known remote names, used as the pool of selectable remotes. */
+  remoteNames?: string[]
+}
+const props = defineProps<Props>()
+const { t } = useI18n()
+
+const form = reactive({
+  name: props.shardName ?? '',
+  remotes: [...(props.remotes ?? [])],
+})
+
+const payload = () => ({ name: form.name, remotes: [...form.remotes] })
+</script>
+
+<i18n>
+en:
+  title:
+    create: Add shard
+    edit: Edit shard
+  labels:
+    name: Name
+    remotes: Remotes
+  hints:
+    remotes: Select which remotes belong to this shard.
+  placeholders:
+    name: shard-00
+    remotes: No remotes selected
+</i18n>

--- a/app/components/network/types.ts
+++ b/app/components/network/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Local types for the Meilisearch Network topology (>= 1.37).
+ *
+ * The installed `meilisearch` client (v0.51.0) ships an OLDER `Network`/`Remote`
+ * shape (only `self` + `remotes{url, searchApiKey}`). The 1.37+ topology adds
+ * `leader`, `writeApiKey` on remotes, and `shards`. We define our own types here
+ * rather than editing node_modules or relying on the stale client types, and cast
+ * the client's `getNetwork()` / `updateNetwork()` results to these.
+ *
+ * @see https://www.meilisearch.com/docs/reference/api/network
+ */
+
+export type Remote = {
+  url: string
+  searchApiKey: string | null
+  writeApiKey: string | null
+}
+
+export type Shard = {
+  remotes: string[]
+}
+
+export type NetworkTopology = {
+  self: string | null
+  leader: string | null
+  remotes: Record<string, Remote>
+  shards: Record<string, Shard>
+}
+
+/**
+ * Partial payload for PATCH /network.
+ *
+ * - `remotes`: a `null` value removes that remote (auto-removed from shards too).
+ * - `shards`: each entry supports `remotes` (replace all), `addRemotes`, `removeRemotes`,
+ *   applied in that order. A `null` shard value removes the shard.
+ */
+export type NetworkUpdate = {
+  self?: string | null
+  leader?: string | null
+  remotes?: Record<string, Partial<Remote> | null>
+  shards?: Record<string, { remotes?: string[]; addRemotes?: string[]; removeRemotes?: string[] } | null>
+}

--- a/app/pages/network/index.vue
+++ b/app/pages/network/index.vue
@@ -1,0 +1,380 @@
+<template>
+  <Layout :title="t('title')" :subtitle="t('subtitle')">
+    <template #title-actions>
+      <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/network" />
+    </template>
+
+    <Alert v-if="loadError" theme="danger" :title="t('errors.unavailable.title')">
+      {{ t('errors.unavailable.text') }}
+    </Alert>
+
+    <div v-else class="space-y-8">
+      <!-- Identity: self & leader -->
+      <section class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <h2 class="mb-1 text-lg font-semibold text-gray-900">{{ t('identity.title') }}</h2>
+        <p class="mb-4 text-sm text-gray-500">{{ t('identity.subtitle') }}</p>
+        <form class="flex flex-col gap-4 sm:flex-row sm:items-end" @submit.prevent="saveIdentity()">
+          <UniqueId as="div" v-slot="{ id }" class="flex flex-1 flex-col gap-1">
+            <Label :for="id">{{ t('identity.self') }}</Label>
+            <input
+              :id
+              v-model.trim="identity.self"
+              type="text"
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck="false"
+              :placeholder="t('identity.selfPlaceholder')"
+              class="form-input w-full" />
+          </UniqueId>
+          <UniqueId as="div" v-slot="{ id }" class="flex flex-1 flex-col gap-1">
+            <Label :for="id">{{ t('identity.leader') }}</Label>
+            <input
+              :id
+              v-model.trim="identity.leader"
+              type="text"
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck="false"
+              :placeholder="t('identity.leaderPlaceholder')"
+              class="form-input w-full" />
+          </UniqueId>
+          <Button type="submit" theme="primary" :disabled="!identityChanged">
+            {{ t('actions.save') }}
+          </Button>
+        </form>
+      </section>
+
+      <!-- Remotes -->
+      <section class="space-y-3">
+        <header class="flex items-center justify-between">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">{{ t('remotes.title') }}</h2>
+            <p class="text-sm text-gray-500">{{ t('remotes.subtitle') }}</p>
+          </div>
+          <Button theme="primary" icon="heroicons:plus" @click="addRemote()">
+            {{ t('actions.addRemote') }}
+          </Button>
+        </header>
+
+        <Table
+          v-if="remoteEntries.length"
+          :items="remoteEntries"
+          :columns="[
+            t('columns.name'),
+            t('columns.url'),
+            t('columns.searchApiKey'),
+            t('columns.writeApiKey'),
+            t('columns.actions'),
+          ]">
+          <template #default="{ index: i }">
+            <td class="font-medium">{{ remoteEntries[i].name }}</td>
+            <td class="break-all">{{ remoteEntries[i].url }}</td>
+            <td>
+              <span v-if="remoteEntries[i].searchApiKey" class="font-mono text-sm">
+                {{ remoteEntries[i].searchApiKey }}
+              </span>
+              <span v-else class="text-sm font-light italic text-gray-500">{{ t('placeholders.none') }}</span>
+            </td>
+            <td>
+              <span v-if="remoteEntries[i].writeApiKey" class="font-mono text-sm">
+                {{ remoteEntries[i].writeApiKey }}
+              </span>
+              <span v-else class="text-sm font-light italic text-gray-500">{{ t('placeholders.none') }}</span>
+            </td>
+            <td>
+              <div class="flex items-center gap-2">
+                <button
+                  type="button"
+                  v-tippy="t('actions.edit')"
+                  class="text-gray-500 hover:text-primary-600"
+                  @click="editRemote(remoteEntries[i])">
+                  <Icon name="heroicons:pencil-square" />
+                </button>
+                <button
+                  type="button"
+                  v-tippy="t('actions.delete')"
+                  class="text-gray-500 hover:text-red-600"
+                  @click="removeRemote(remoteEntries[i].name)">
+                  <Icon name="heroicons:trash" />
+                </button>
+              </div>
+            </td>
+          </template>
+        </Table>
+        <p v-else class="rounded-lg border border-dashed border-gray-300 px-4 py-6 text-center text-sm text-gray-500">
+          {{ t('remotes.empty') }}
+        </p>
+      </section>
+
+      <!-- Shards -->
+      <section class="space-y-3">
+        <header class="flex items-center justify-between">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">{{ t('shards.title') }}</h2>
+            <p class="text-sm text-gray-500">{{ t('shards.subtitle') }}</p>
+          </div>
+          <Button theme="primary" icon="heroicons:plus" :disabled="!remoteNames.length" @click="addShard()">
+            {{ t('actions.addShard') }}
+          </Button>
+        </header>
+
+        <Table
+          v-if="shardEntries.length"
+          :items="shardEntries"
+          :columns="[t('columns.name'), t('columns.remotes'), t('columns.actions')]">
+          <template #default="{ index: i }">
+            <td class="font-medium">{{ shardEntries[i].name }}</td>
+            <td>
+              <div v-if="shardEntries[i].remotes.length" class="flex flex-wrap gap-1">
+                <Badge v-for="name in shardEntries[i].remotes" :key="name" theme="neutral">{{ name }}</Badge>
+              </div>
+              <span v-else class="text-sm font-light italic text-gray-500">{{ t('placeholders.none') }}</span>
+            </td>
+            <td>
+              <div class="flex items-center gap-2">
+                <button
+                  type="button"
+                  v-tippy="t('actions.edit')"
+                  class="text-gray-500 hover:text-primary-600"
+                  @click="editShard(shardEntries[i])">
+                  <Icon name="heroicons:pencil-square" />
+                </button>
+                <button
+                  type="button"
+                  v-tippy="t('actions.delete')"
+                  class="text-gray-500 hover:text-red-600"
+                  @click="removeShard(shardEntries[i].name)">
+                  <Icon name="heroicons:trash" />
+                </button>
+              </div>
+            </td>
+          </template>
+        </Table>
+        <p v-else class="rounded-lg border border-dashed border-gray-300 px-4 py-6 text-center text-sm text-gray-500">
+          {{ t('shards.empty') }}
+        </p>
+      </section>
+    </div>
+  </Layout>
+</template>
+
+<script setup lang="ts">
+import Layout from '~/components/layout/Layout.vue'
+import Alert from '~/components/layout/Alert.vue'
+import Badge from '~/components/layout/Badge.vue'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import Table from '~/components/layout/tables/Table.vue'
+import RemoteEditorModal from '~/components/network/RemoteEditorModal.vue'
+import ShardEditorModal from '~/components/network/ShardEditorModal.vue'
+import type { NetworkTopology, NetworkUpdate, Remote } from '~/components/network/types'
+import { useMeiliClient } from '~/composables'
+import {
+  DismissedDialog,
+  TOAST_FAILURE,
+  TOAST_PLEASEWAIT,
+  TOAST_SUCCESS,
+  useConfirmationDialog,
+  usePromisifiedDialogs,
+  useToasts,
+} from '~/stores'
+
+type RemoteEntry = { name: string } & Remote
+type ShardEntry = { name: string; remotes: string[] }
+
+const { t } = useI18n()
+const meili = useMeiliClient()
+const { createToast } = useToasts()
+const { confirm } = useConfirmationDialog()
+const { openDialog } = usePromisifiedDialogs()
+
+// Register lifecycle-bound composables before the first `await` so they keep their component context.
+useHead({ title: t('title') })
+
+const empty = (): NetworkTopology => ({ self: null, leader: null, remotes: {}, shards: {} })
+
+const self = reactive({
+  network: empty() as NetworkTopology,
+  loadError: false,
+})
+
+const load = async () => {
+  // Direct call (not tryOrThrow): we degrade gracefully rather than route to the global fatal
+  // error page, since an older instance (or one with the `network` feature disabled) returns 404.
+  const raw = (await meili.getNetwork()) as unknown as Partial<NetworkTopology>
+  self.network = {
+    self: raw.self ?? null,
+    leader: raw.leader ?? null,
+    remotes: raw.remotes ?? {},
+    shards: raw.shards ?? {},
+  }
+}
+
+try {
+  await load()
+} catch {
+  self.loadError = true
+}
+
+// Editable copy of self/leader; reset whenever the network reloads.
+const identity = reactive({ self: self.network.self ?? '', leader: self.network.leader ?? '' })
+watch(
+  () => self.network,
+  (network) => {
+    identity.self = network.self ?? ''
+    identity.leader = network.leader ?? ''
+  },
+)
+
+const identityChanged = computed(
+  () => identity.self !== (self.network.self ?? '') || identity.leader !== (self.network.leader ?? ''),
+)
+
+const remoteEntries = computed<RemoteEntry[]>(() =>
+  Object.entries(self.network.remotes).map(([name, remote]) => ({ name, ...remote })),
+)
+const remoteNames = computed(() => Object.keys(self.network.remotes))
+const shardEntries = computed<ShardEntry[]>(() =>
+  Object.entries(self.network.shards).map(([name, shard]) => ({ name, remotes: shard.remotes ?? [] })),
+)
+
+/**
+ * Apply a partial PATCH and refresh from the server response. /network is synchronous
+ * (no task object), so we don't wrap it in useTask. Returns the updated topology.
+ */
+const patch = async (update: NetworkUpdate, toastTitle: string) => {
+  const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: toastTitle })
+  try {
+    const updated = (await meili.updateNetwork(update as never)) as unknown as Partial<NetworkTopology>
+    self.network = {
+      self: updated.self ?? null,
+      leader: updated.leader ?? null,
+      remotes: updated.remotes ?? {},
+      shards: updated.shards ?? {},
+    }
+    toast.update({ ...TOAST_SUCCESS(t) })
+  } catch (e) {
+    toast.update({ ...TOAST_FAILURE(t) })
+    throw e
+  }
+}
+
+const saveIdentity = () =>
+  patch({ self: identity.self || null, leader: identity.leader || null }, t('toasts.savingIdentity')).catch(() => {})
+
+const addRemote = async () => {
+  try {
+    const entry = (await openDialog(RemoteEditorModal, { existingNames: remoteNames.value })) as RemoteEntry
+    await upsertRemote(entry)
+  } catch (e) {
+    if (!(e instanceof DismissedDialog)) throw e
+  }
+}
+
+const editRemote = async (remote: RemoteEntry) => {
+  try {
+    const entry = (await openDialog(RemoteEditorModal, { remote })) as RemoteEntry
+    await upsertRemote(entry)
+  } catch (e) {
+    if (!(e instanceof DismissedDialog)) throw e
+  }
+}
+
+const upsertRemote = (entry: RemoteEntry) => {
+  const { name, ...remote } = entry
+  return patch({ remotes: { [name]: remote } }, t('toasts.savingRemote', { name })).catch(() => {})
+}
+
+const removeRemote = async (name: string) => {
+  if (!(await confirm({ text: t('confirmations.removeRemote', { name }) }))) return
+  // Passing `null` removes the remote; Meilisearch auto-removes it from any shards too.
+  await patch({ remotes: { [name]: null } }, t('toasts.removingRemote', { name })).catch(() => {})
+}
+
+const addShard = async () => {
+  try {
+    const result = (await openDialog(ShardEditorModal, { remoteNames: remoteNames.value })) as ShardEntry
+    await patch(
+      { shards: { [result.name]: { remotes: result.remotes } } },
+      t('toasts.savingShard', { name: result.name }),
+    ).catch(() => {})
+  } catch (e) {
+    if (!(e instanceof DismissedDialog)) throw e
+  }
+}
+
+const editShard = async (shard: ShardEntry) => {
+  try {
+    const result = (await openDialog(ShardEditorModal, {
+      shardName: shard.name,
+      remotes: shard.remotes,
+      remoteNames: remoteNames.value,
+    })) as ShardEntry
+    // A non-null `remotes` array replaces the whole set for this shard.
+    await patch(
+      { shards: { [result.name]: { remotes: result.remotes } } },
+      t('toasts.savingShard', { name: result.name }),
+    ).catch(() => {})
+  } catch (e) {
+    if (!(e instanceof DismissedDialog)) throw e
+  }
+}
+
+const removeShard = async (name: string) => {
+  if (!(await confirm({ text: t('confirmations.removeShard', { name }) }))) return
+  await patch({ shards: { [name]: null } }, t('toasts.removingShard', { name })).catch(() => {})
+}
+
+const { loadError } = toRefs(self)
+</script>
+
+<i18n>
+en:
+  title: Network
+  subtitle: Manage this instance's network topology — its identity, remote instances and shards.
+  errors:
+    unavailable:
+      title: Network unavailable
+      text: This Meilisearch instance does not expose the network endpoint.
+            It may be running a version older than 1.37, or the "network" experimental feature is disabled.
+  identity:
+    title: Identity
+    subtitle: The name of this instance in the network and the current leader.
+    self: Self
+    selfPlaceholder: 'e.g. ms-0'
+    leader: Leader
+    leaderPlaceholder: 'e.g. ms-0'
+  remotes:
+    title: Remotes
+    subtitle: Other Meilisearch instances participating in this network.
+    empty: No remotes configured yet.
+  shards:
+    title: Shards
+    subtitle: Groups of remotes that documents are distributed across.
+    empty: No shards configured yet.
+  columns:
+    name: Name
+    url: URL
+    searchApiKey: Search API key
+    writeApiKey: Write API key
+    remotes: Remotes
+    actions: Actions
+  placeholders:
+    none: None
+  actions:
+    save: Save
+    addRemote: Add remote
+    addShard: Add shard
+    edit: Edit
+    delete: Delete
+  confirmations:
+    removeRemote: 'Do you really want to remove the remote "{name}"?'
+    removeShard: 'Do you really want to remove the shard "{name}"?'
+  toasts:
+    savingIdentity: Saving network identity...
+    savingRemote: 'Saving remote "{name}"...'
+    removingRemote: 'Removing remote "{name}"...'
+    savingShard: 'Saving shard "{name}"...'
+    removingShard: 'Removing shard "{name}"...'
+</i18n>


### PR DESCRIPTION
## Summary

Adds a new **`/network`** route to view and manage Meilisearch's **network topology** (cluster management), and a **Network** entry in the main navigation right after **Tasks**.

The page lets users:

- **Identity** — view and edit `self` and `leader` (saved via a single PATCH).
- **Remotes** — add / edit / remove remote instances (`url`, `searchApiKey`, `writeApiKey`). Uses the project's promisified-dialog pattern for the add/edit form and the confirmation dialog for removal (mirrors `webhooks/index.vue`).
- **Shards** — list shard → its remotes and assign/remove remotes per shard via a modal that selects from the known remote names. A non-null `remotes` array replaces the shard's set.

All mutations go through the synchronous `PATCH /network` route (no task object, so **not** wrapped in `useTask`), surface progress via toasts, and refresh from the server response.

## Requirements

- Meilisearch **>= 1.37**
- The **`network`** experimental feature must be enabled on the instance (`PATCH /experimental-features {"network": true}`).

When the endpoint is unavailable (older instance or feature disabled), the page **degrades gracefully** with an `Alert` — exactly like `experimental-features.vue` (direct try/catch, no global fatal page).

## Implementation notes

- The installed `meilisearch` client (**v0.51.0**) ships **stale** `Network`/`Remote` TypeScript types (only `self` + `remotes{url, searchApiKey}`). Rather than editing `node_modules` or relying on those types, local types for the full 1.37+ topology live in `app/components/network/types.ts`, and the client's `getNetwork()` / `updateNetwork()` results are cast.

## Files changed

- `app/pages/network/index.vue` — the page (load, identity, remotes CRUD, shards, toasts, graceful degradation).
- `app/components/network/types.ts` — local topology types.
- `app/components/network/RemoteEditorModal.vue` — add/edit remote (promisified dialog).
- `app/components/network/ShardEditorModal.vue` — edit shard remotes (promisified dialog + MultiCombobox).
- `app/components/layout/TopNavigation.vue` — add the `Network` nav entry after `Tasks`.

## Testing

- `yarn format`, `yarn run check` (eslint) and `yarn build` all pass.
- **Live smoke-tested** against a local Meilisearch with the `network` feature enabled, driven via Playwright:
  - Navigation renders `Network` after `Tasks`.
  - Adding a remote (`ms-1`, url, searchApiKey, writeApiKey) persists server-side; it shows in the table.
  - Removing it via the confirmation dialog clears it server-side.
  - Editing identity (`self = ms-0`) persists server-side.
  - Disabling the `network` feature → the page shows the "Network unavailable" Alert instead of crashing.

### Caveats

- The locally available Meilisearch binary is **1.31.0** (< 1.37). It exposes `self` / `leader` / `remotes` (incl. `writeApiKey`) but **not** `shards` (rejects `shards` in PATCH). So the **shards UI was not exercised against a live server** — the rest of the topology (identity + remotes CRUD + graceful degradation) was. The shards code follows the documented PATCH semantics; please verify against a >= 1.37 instance if convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
