### PR TITLE
Chore: upgrade meilisearch client to 0.59.0

### DIFF
--- a/app/composables/useTask.ts
+++ b/app/composables/useTask.ts
@@ -1,5 +1,5 @@
 import match from 'match-operator'
-import { type EnqueuedTask, MeiliSearchRequestTimeOutError, type Task } from 'meilisearch'
+import { type EnqueuedTask, MeilisearchRequestTimeOutError, type Task } from 'meilisearch'
 import { useMeiliClient } from '~/composables/index'
 
 type EnqueuedTaskPromise = () => Promise<EnqueuedTask>
@@ -8,7 +8,7 @@ type ProcessTaskOptions = {
   onSuccess: (task: Task) => void
   onCanceled: (task: Task) => void
   onFailure: (task: Task) => void
-  onTimeout: (e: MeiliSearchRequestTimeOutError, enqueuedTask: EnqueuedTask) => void
+  onTimeout: (e: MeilisearchRequestTimeOutError, enqueuedTask: EnqueuedTask) => void
 }
 
 export class TaskError extends Error {
@@ -56,7 +56,7 @@ export const useTask = () => {
       ])
       return task
     } catch (e) {
-      if (e instanceof MeiliSearchRequestTimeOutError) {
+      if (e instanceof MeilisearchRequestTimeOutError) {
         onTimeout(e, enqueuedTask)
         return enqueuedTask
       }

--- a/app/utils/try-or-throw.ts
+++ b/app/utils/try-or-throw.ts
@@ -1,4 +1,4 @@
-import { MeiliSearchApiError } from 'meilisearch'
+import { MeilisearchApiError } from 'meilisearch'
 
 type PromiseCallback<T> = () => Promise<T>
 
@@ -7,7 +7,7 @@ export const tryOrThrow = async <T>(promiseCallback: PromiseCallback<T>): Promis
     return await promiseCallback()
   } catch (e) {
     throw createError({
-      statusCode: e instanceof MeiliSearchApiError ? e.httpStatus : 400,
+      statusCode: e instanceof MeilisearchApiError ? e.response.status : 400,
       statusMessage: (e as Error).message,
       fatal: true,
     })

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jwt-encode": "^1.0.1",
     "leaflet": "^1.9.4",
     "match-operator": "^0.3.1",
-    "meilisearch": "^0.51.0",
+    "meilisearch": "^0.59.0",
     "meilisearch-filters": "^1.1.0",
     "nuxt": "^4.4.8",
     "pinia": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6492,10 +6492,10 @@ meilisearch-filters@^1.1.0:
   resolved "https://registry.yarnpkg.com/meilisearch-filters/-/meilisearch-filters-1.1.0.tgz#fecc51c5e97239a328702b703e080f05a5ac3b5f"
   integrity sha512-CAUNisEDynkmXBLoZmpiolsskdOcpQ3m3OolZzclhx2QcB2Yj7b4irG6v9pUh/MQa2vAL7DgpoR8Qu+WbSYr+A==
 
-meilisearch@^0.51.0:
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.51.0.tgz#508ab5bb2c2935e0f2ff71de1cf28fef598ca050"
-  integrity sha512-IuNsYyT8r/QLhU33XDZdXWUT6cA/nACCHHZc+NHkNuaU55LELRxff1uBJhpJcwjYaAPEEmeWrzBhYl2XlhJdAg==
+meilisearch@^0.59.0:
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.59.0.tgz#9b38d213a631e00fd9e61efd72b068a4a4ecdcf4"
+  integrity sha512-9KxasX98+qYhOVa4PPeaX/yY/ukM9DMuJlUJRgJVwrdCkWw+mkkiIh6EJmYyCxU8nXhj0VEzdYr3dNUJT1BQow==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
- Bumps the `meilisearch` JS client from `0.51.0` to `0.59.0` (8 minor releases, ~4 months of upstream work — webhooks, chat/conversational search, network sharding, index fields API, foreign filters, etc.)
- Adapts to the v0.57.0 breaking rename of error classes: `MeiliSearchApiError` → `MeilisearchApiError`, `MeiliSearchRequestTimeOutError` → `MeilisearchRequestTimeOutError`
- Adapts to the removal of `MeilisearchApiError#httpStatus`: now reads `error.response.status` instead

## Test plan
- [x] `yarn build` — production build succeeds, no type errors
- [x] `yarn run check` (eslint) and `yarn run lint` (prettier) pass
- [x] Manual smoke test against a local Meilisearch 1.47.0 instance via Playwright:
  - [x] Login flow works, instance version correctly displayed
  - [x] Creating an index (exercises `useTask`/`waitForTask`) succeeds with no console errors
  - [x] Navigating to a non-existent index correctly surfaces a 404 error page (exercises `tryOrThrow`/`MeilisearchApiError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)