### PR TITLE
Feat: hybrid (semantic + keyword) search on indexes with embedders

### DIFF
--- a/app/components/documents/HybridSearchControl.vue
+++ b/app/components/documents/HybridSearchControl.vue
@@ -1,0 +1,69 @@
+<template>
+  <UPopover>
+    <button v-tippy="t('actions.toggle')" type="button">
+      <Icon
+        name="ph:magic-wand-fill"
+        :class="[
+          'size-6',
+          enabled ? 'text-primary-600 hover:text-primary-800' : 'text-gray-600 hover:text-gray-800',
+        ]" />
+    </button>
+
+    <template #content>
+      <div class="w-72 space-y-4 p-4">
+        <USwitch v-model="enabled" :label="t('labels.enable')" />
+
+        <div class="flex flex-col gap-1" :class="{ 'opacity-50': !enabled }">
+          <Label>{{ t('labels.embedder') }}</Label>
+          <Select v-model="embedder" :disabled="!enabled" class="w-full">
+            <option v-for="name of embedders" :key="name" :value="name">{{ name }}</option>
+          </Select>
+        </div>
+
+        <div class="flex flex-col gap-2" :class="{ 'opacity-50': !enabled }">
+          <div class="flex items-center justify-between text-xs text-gray-500">
+            <span>{{ t('labels.keywordSearch') }}</span>
+            <span>{{ t('labels.semanticSearch') }}</span>
+          </div>
+          <RangeSlider
+            v-model="semanticRatio"
+            :min="0"
+            :max="1"
+            :step="0.01"
+            :disabled="!enabled"
+            :format="formatRatio"
+            class="w-full" />
+        </div>
+      </div>
+    </template>
+  </UPopover>
+</template>
+
+<script setup lang="ts">
+import Label from '~/components/layout/forms/Label.vue'
+import Select from '~/components/layout/forms/Select.vue'
+import RangeSlider from '~/components/layout/RangeSlider.vue'
+
+type Props = {
+  embedders: string[]
+}
+defineProps<Props>()
+
+const enabled = defineModel<boolean>('enabled', { default: false })
+const embedder = defineModel<string | null>('embedder', { default: null })
+const semanticRatio = defineModel<number>('semanticRatio', { default: 0.5 })
+
+const { t } = useI18n()
+const formatRatio = (value: number) => `${Math.round(value * 100)}%`
+</script>
+
+<i18n>
+en:
+  actions:
+    toggle: Hybrid search (semantic + keyword)
+  labels:
+    enable: Enable hybrid search
+    embedder: Embedder
+    keywordSearch: Keyword
+    semanticSearch: Semantic
+</i18n>

--- a/app/composables/useIndexLocalSettings.ts
+++ b/app/composables/useIndexLocalSettings.ts
@@ -11,11 +11,20 @@ type UseIndexLocalSettings = {
   itemsPerPage: number
   viewMode: ViewMode
   updateMode: UpdateMode
+  hybridEnabled: boolean
+  hybridEmbedder: string | null
+  hybridSemanticRatio: number
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
 const DEFAULT_VIEW_MODE = 'documents'
 const DEFAULT_UPDATE_MODE = 'replace'
+// Hybrid search is opt-in: keyword search must keep working exactly as before unless the
+// user explicitly turns it on, so `hybridEnabled` defaults to false regardless of how many
+// embedders the index has. 0.5 matches the Meilisearch API default for `semanticRatio`.
+const DEFAULT_HYBRID_ENABLED = false
+const DEFAULT_HYBRID_EMBEDDER = null
+const DEFAULT_HYBRID_SEMANTIC_RATIO = 0.5
 
 export const useIndexLocalSettings = (indexUid: string) => {
   const { credentials } = useCredentials()
@@ -28,6 +37,9 @@ export const useIndexLocalSettings = (indexUid: string) => {
     itemsPerPage: DEFAULT_ITEMS_PER_PAGE,
     viewMode: DEFAULT_VIEW_MODE,
     updateMode: DEFAULT_UPDATE_MODE,
+    hybridEnabled: DEFAULT_HYBRID_ENABLED,
+    hybridEmbedder: DEFAULT_HYBRID_EMBEDDER,
+    hybridSemanticRatio: DEFAULT_HYBRID_SEMANTIC_RATIO,
   })
 
   const self = reactive({ storage })
@@ -61,5 +73,26 @@ export const useIndexLocalSettings = (indexUid: string) => {
       get: () => self.storage.updateMode ?? DEFAULT_UPDATE_MODE,
       set: (value: UpdateMode) => (self.storage.updateMode = value),
     }),
+    hybridEnabled: computed({
+      get: () => self.storage.hybridEnabled ?? DEFAULT_HYBRID_ENABLED,
+      set: (value: boolean) => (self.storage.hybridEnabled = value),
+    }),
+    hybridEmbedder: computed({
+      get: () => self.storage.hybridEmbedder ?? DEFAULT_HYBRID_EMBEDDER,
+      set: (value: string | null) => (self.storage.hybridEmbedder = value),
+    }),
+    hybridSemanticRatio: computed({
+      get: () => self.storage.hybridSemanticRatio ?? DEFAULT_HYBRID_SEMANTIC_RATIO,
+      set: (value: number) => (self.storage.hybridSemanticRatio = value),
+    }),
+    // Call this whenever the stored embedder no longer matches the index's live embedder
+    // list (renamed/deleted) — resets everything hybrid-related to its default in one go,
+    // so no caller can reset one field and forget the others (e.g. leaving a stale
+    // semanticRatio next to an empty embedder).
+    resetHybridSearch: () => {
+      self.storage.hybridEnabled = DEFAULT_HYBRID_ENABLED
+      self.storage.hybridEmbedder = DEFAULT_HYBRID_EMBEDDER
+      self.storage.hybridSemanticRatio = DEFAULT_HYBRID_SEMANTIC_RATIO
+    },
   }
 }

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -43,21 +43,31 @@
         :ui="{ base: 'rounded-lg' }"
         class="grow lg:w-80" />
 
+      <HybridSearchControl
+        v-if="hasEmbedders"
+        v-model:enabled="hybridEnabled"
+        v-model:embedder="hybridEmbedder"
+        v-model:semantic-ratio="hybridSemanticRatio"
+        :embedders="embedderNames" />
+
       <button v-tippy="t('actions.documentView')" @click="viewMode = 'documents'">
         <Icon
           name="fa-solid:id-card"
           :class="['documents' === viewMode ? 'text-primary-700' : 'text-gray-600 hover:text-gray-800', 'size-6']" />
       </button>
+
       <button v-tippy="t('actions.tableView')" type="button" @click="viewMode = 'table'">
         <Icon
           name="nimbus:list"
           :class="['table' === viewMode ? 'text-primary-700' : 'text-gray-600 hover:text-gray-800', 'size-6']" />
       </button>
+
       <button v-if="hasGeoDocuments" v-tippy="t('actions.mapView')" type="button" @click="viewMode = 'map'">
         <Icon
           name="gis:poi-map"
           :class="['map' === viewMode ? 'text-primary-700' : 'text-gray-600 hover:text-gray-800', 'size-6']" />
       </button>
+
       <button v-tippy="t('actions.toggleFilters')" @click="filterPanelOpen = true">
         <Icon
           name="ph:funnel-fill"
@@ -66,12 +76,6 @@
             appliedFilters.length > 0 ? 'text-primary-600 hover:text-primary-800' : 'text-gray-600 hover:text-gray-800'
           " />
       </button>
-      <HybridSearchControl
-        v-if="hasEmbedders"
-        v-model:enabled="hybridEnabled"
-        v-model:embedder="hybridEmbedder"
-        v-model:semantic-ratio="hybridSemanticRatio"
-        :embedders="embedderNames" />
     </template>
     <template #title-actions>
       <NuxtLink :to="`/indexes/${index.uid}/settings`" v-tippy="t('actions.goToSettings')">

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -66,6 +66,12 @@
             appliedFilters.length > 0 ? 'text-primary-600 hover:text-primary-800' : 'text-gray-600 hover:text-gray-800'
           " />
       </button>
+      <HybridSearchControl
+        v-if="hasEmbedders"
+        v-model:enabled="hybridEnabled"
+        v-model:embedder="hybridEmbedder"
+        v-model:semantic-ratio="hybridSemanticRatio"
+        :embedders="embedderNames" />
     </template>
     <template #title-actions>
       <NuxtLink :to="`/indexes/${index.uid}/settings`" v-tippy="t('actions.goToSettings')">
@@ -113,6 +119,7 @@ import DocumentsAsCards from '~/components/documents/DocumentsAsCards.vue'
 import DocumentsAsTable from '~/components/documents/DocumentsAsTable.vue'
 import Button from '~/components/layout/forms/Button.vue'
 import DocumentsAsMap from '~/components/documents/DocumentsAsMap.vue'
+import HybridSearchControl from '~/components/documents/HybridSearchControl.vue'
 import { reactiveComputed } from '@vueuse/core'
 
 const { t } = useI18n()
@@ -134,16 +141,57 @@ const filterableAttributes = getFilterableAttributePatterns(rawFilterableAttribu
 const facetSearchableAttributes = getFacetSearchableAttributePatterns(rawFilterableAttributes)
 
 const { fields } = useFields(primaryKey, Object.keys(stats.fieldDistribution))
-const { appliedSort, facets, itemsPerPage, viewMode } = useIndexLocalSettings(index.uid)
+const {
+  appliedSort,
+  facets,
+  itemsPerPage,
+  viewMode,
+  hybridEnabled,
+  hybridEmbedder,
+  hybridSemanticRatio,
+  resetHybridSearch,
+} = useIndexLocalSettings(index.uid)
 const appliedFilters = reactive(new AppliedFilters()) as AppliedFilters
 const searchTerms = ref('')
 const { offset, totalItems, currentPage, previousPage, nextPage, lastPage } = usePagination(itemsPerPage)
+
+// Direct call (not tryOrThrow): older instances (or ones without the vector store feature
+// enabled) don't expose embedders — degrade to "no hybrid search" rather than the fatal
+// error page. See app/pages/experimental-features.vue for the same pattern.
+let embedders: Record<string, unknown> = {}
+try {
+  embedders = (await index.getEmbedders()) ?? {}
+} catch {
+  embedders = {}
+}
+const embedderNames = Object.keys(embedders)
+const hasEmbedders = embedderNames.length > 0
+
+// The embedder stored in localStorage may no longer exist (renamed/deleted since the user
+// last configured hybrid search) — reconcile against the live list *before* it can ever be
+// sent to Meilisearch, which would otherwise reject the search and break the page.
+if (!hasEmbedders) {
+  if (hybridEnabled.value || hybridEmbedder.value) resetHybridSearch()
+} else if (hybridEmbedder.value && !embedderNames.includes(hybridEmbedder.value)) {
+  resetHybridSearch()
+}
+// Pre-select an embedder for convenience once one exists — this only fills the dropdown,
+// it does NOT turn hybrid search on (hybridEnabled stays whatever it was/defaults to false).
+if (hasEmbedders && !hybridEmbedder.value) {
+  hybridEmbedder.value = embedderNames[0]
+}
+
 const searchParams = reactive({
   q: searchTerms,
   sort: appliedSort,
   limit: itemsPerPage,
   offset,
   filter: computed(() => `${appliedFilters}`),
+  hybrid: computed(() =>
+    hybridEnabled.value && hybridEmbedder.value
+      ? { embedder: hybridEmbedder.value, semanticRatio: hybridSemanticRatio.value }
+      : undefined,
+  ),
 })
 const resultset = ref(await tryOrThrow(() => searchClient.index(index.uid).search(null, searchParams)))
 
@@ -165,6 +213,9 @@ watch(appliedSort, () => (searchParams.offset = 0))
 watch(appliedFilters, () => (searchParams.offset = 0))
 watch(itemsPerPage, () => (searchParams.offset = 0))
 watch(searchTerms, () => (searchParams.offset = 0))
+watch(hybridEnabled, () => (searchParams.offset = 0))
+watch(hybridEmbedder, () => (searchParams.offset = 0))
+watch(hybridSemanticRatio, () => (searchParams.offset = 0))
 watch(
   searchParams,
   async (searchParams) => (self.resultset = await searchClient.index(index.uid).search(null, searchParams)),


### PR DESCRIPTION
Offers hybrid (semantic + keyword) search on the documents page **when the index has at least one embedder**. Indexes without an embedder are completely unaffected — no new UI, no change to the search params.

## Changes

- **`app/components/documents/HybridSearchControl.vue`** (new) — wand icon next to the filter button (tinted primary when active) opening a `UPopover` with a `USwitch` (enable), an embedder `Select`, and a `RangeSlider` for `semanticRatio` (0 to 1, shown as a percentage, Keyword ↔ Semantic).
- **`app/composables/useIndexLocalSettings.ts`** — three new persisted fields (`hybridEnabled`, `hybridEmbedder`, `hybridSemanticRatio`) plus a `resetHybridSearch()` that clears all three at once, so no caller can reset one and forget the others.
- **`app/pages/indexes/[indexUid]/documents/index.vue`** — fetches the index embedders, renders the control only when there are any, and adds `hybrid` to the search params.

## Default state: off

Hybrid search is **opt-in**, even when the index has exactly one embedder. The only automatic behaviour is pre-filling the dropdown with the first embedder found — the switch stays off until the user flips it. Silently turning semantic search on would change results under a user who never asked for it.

## Stale embedder handling

The fiddly bit. If the embedder stored in localStorage no longer exists (renamed or deleted since the user last configured this), sending it would make Meilisearch reject the search and break the page.

Reconciliation runs at page setup, **before** the first search:

- index has no embedders at all, but hybrid state is stored → `resetHybridSearch()`
- stored embedder is not in the live list → `resetHybridSearch()`

Silent, no error surfaced, all three fields reset together. And `searchParams.hybrid` is a computed that yields `undefined` unless both `hybridEnabled` and `hybridEmbedder` hold — `JSON.stringify` drops it, so a half-configured state can never reach the API.

Note: the embedder list is read once per page setup. Editing embedders happens on another route, so coming back re-runs the reconciliation. There is no live watcher on the embedder list.

## Needs a human eye 👀

Nothing here was verified in a browser (worktrees in this batch share one `node_modules`, so no dev server was run):

- Real hybrid search against a configured embedder — no OpenAI/HuggingFace key available, so the actual effect of `semanticRatio` is untested.
- **`UPopover` rendering** — first use of this component in the repo, no existing precedent for positioning or styling to compare against.
- Graceful degradation when `getEmbedders()` 404s on an older instance (coded, not exercised).

Verified by reading the dependencies rather than assumed: `step`/`disabled` do fall through to `@vueform/slider` (`RangeSlider.vue` has a single root element), and that slider's `lazy` prop defaults to `true`, so dragging fires one search on release rather than one per step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
