### PR TITLE
Feat: export all or part of an instance to a remote Meilisearch (Export API)

### DIFF
--- a/app/components/export/ExportForm.vue
+++ b/app/components/export/ExportForm.vue
@@ -22,6 +22,18 @@
       <datalist id="export-destinations">
         <option v-for="destination of destinations" :key="destination" :value="destination" />
       </datalist>
+      <div v-if="destinations.length > 0" class="flex flex-wrap items-center gap-2">
+        <span class="text-xs font-light text-gray-500 italic">{{ t('hints.recentDestinations') }}</span>
+        <Button
+          v-for="destination of destinations"
+          :key="destination"
+          type="button"
+          theme="secondary"
+          size="small"
+          @click="form.url = destination">
+          {{ destination }}
+        </Button>
+      </div>
     </UniqueId>
 
     <UniqueId as="section" v-slot="{ id }" class="space-y-1">
@@ -169,19 +181,28 @@ const submit = () =>
       ...TOAST_PLEASEWAIT(t),
       title: t('toasts.exporting', { url: destination }),
     })
-    await processTask(() => exportToRemote(buildPayload()), {
-      onSuccess: () => toast.update({ ...TOAST_SUCCESS(t) }),
-      onCanceled: () =>
-        toast.update({
-          ...TOAST_FAILURE(t),
-          text: t('toasts.texts.canceledTask'),
-        }),
-      onFailure: () =>
-        toast.update({
-          ...TOAST_FAILURE(t),
-          text: t('toasts.texts.failedTask'),
-        }),
-    })
+    try {
+      await processTask(() => exportToRemote(buildPayload()), {
+        onSuccess: () => toast.update({ ...TOAST_SUCCESS(t) }),
+        onCanceled: () =>
+          toast.update({
+            ...TOAST_FAILURE(t),
+            text: t('toasts.texts.canceledTask'),
+          }),
+        onFailure: () =>
+          toast.update({
+            ...TOAST_FAILURE(t),
+            text: t('toasts.texts.failedTask'),
+          }),
+      })
+    } catch (e) {
+      // A synchronous rejection (e.g. a 400 from `POST /export` on a malformed `payloadSize`) happens
+      // before any task exists, so none of the `processTask` callbacks above ever fire. Without this,
+      // the "please wait" toast is left stuck forever while the inline error banner (via `handle`) shows
+      // the real failure.
+      toast.update({ ...TOAST_FAILURE(t), text: t('toasts.texts.failedTask') })
+      throw e
+    }
   })
 </script>
 
@@ -206,6 +227,7 @@ en:
                       re-entered every time.
     allIndexesByDefault: Leave empty to export every index.
     filter: Only documents matching this filter expression will be exported.
+    recentDestinations: 'Recently used:'
   actions:
     export: Export
   confirmations:

--- a/app/components/export/ExportForm.vue
+++ b/app/components/export/ExportForm.vue
@@ -8,21 +8,19 @@
       {{ error }}
     </Alert>
 
-    <UniqueId as="section" v-slot="{ id }" class="space-y-1">
-      <Label :for="id" required>{{ t('labels.url') }}</Label>
-      <input
-        :id
+    <UFormField :label="t('labels.url')" required>
+      <UInput
         v-model="form.url"
         type="url"
         required
         autofocus
         list="export-destinations"
         :placeholder="t('placeholders.url')"
-        class="form-input w-full" />
+        class="w-full" />
       <datalist id="export-destinations">
         <option v-for="destination of destinations" :key="destination" :value="destination" />
       </datalist>
-      <div v-if="destinations.length > 0" class="flex flex-wrap items-center gap-2">
+      <div v-if="destinations.length > 0" class="mt-2 flex flex-wrap items-center gap-2">
         <span class="text-xs font-light text-gray-500 italic">{{ t('hints.recentDestinations') }}</span>
         <Button
           v-for="destination of destinations"
@@ -34,32 +32,22 @@
           {{ destination }}
         </Button>
       </div>
-    </UniqueId>
+    </UFormField>
 
-    <UniqueId as="section" v-slot="{ id }" class="space-y-1">
-      <Label :for="id">{{ t('labels.apiKey') }}</Label>
-      <input
-        :id
+    <UFormField :label="t('labels.apiKey')" :help="t('hints.apiKeyNotStored')">
+      <UInput
         v-model="form.apiKey"
         type="password"
         autocomplete="off"
         :placeholder="t('placeholders.apiKey')"
-        class="form-input w-full" />
-      <p class="text-xs font-light text-gray-500 italic">{{ t('hints.apiKeyNotStored') }}</p>
-    </UniqueId>
+        class="w-full" />
+    </UFormField>
 
-    <UniqueId as="section" v-slot="{ id }" class="space-y-1">
-      <Label :for="id">{{ t('labels.payloadSize') }}</Label>
-      <input
-        :id
-        v-model="form.payloadSize"
-        type="text"
-        :placeholder="t('placeholders.payloadSize')"
-        class="form-input w-full" />
-    </UniqueId>
+    <UFormField :label="t('labels.payloadSize')">
+      <UInput v-model="form.payloadSize" :placeholder="t('placeholders.payloadSize')" class="w-full" />
+    </UFormField>
 
-    <section v-if="!indexUid" class="space-y-1">
-      <Label>{{ t('labels.indexes') }}</Label>
+    <UFormField v-if="!indexUid" :label="t('labels.indexes')" :help="t('hints.allIndexesByDefault')">
       <UInputMenu
         v-model="form.selectedIndexes"
         multiple
@@ -67,25 +55,15 @@
         open-on-focus
         :items="availableIndexes"
         :placeholder="t('placeholders.indexes')"
-        class="block w-full" />
-      <p class="text-xs font-light text-gray-500 italic">{{ t('hints.allIndexesByDefault') }}</p>
-    </section>
+        class="w-full" />
+    </UFormField>
 
-    <UniqueId v-else as="section" v-slot="{ id }" class="space-y-1">
-      <Label :for="id">{{ t('labels.filter') }}</Label>
-      <input :id v-model="form.filter" type="text" :placeholder="t('placeholders.filter')" class="form-input w-full" />
-      <p class="text-xs font-light text-gray-500 italic">{{ t('hints.filter') }}</p>
-    </UniqueId>
+    <UFormField v-else :label="t('labels.filter')" :help="t('hints.filter')">
+      <UInput v-model="form.filter" :placeholder="t('placeholders.filter')" class="w-full" />
+    </UFormField>
 
-    <div class="flex items-center justify-between">
-      <Label>{{ t('labels.overrideSettings') }}</Label>
-      <USwitch v-model="form.overrideSettings" />
-    </div>
-
-    <div class="flex items-center justify-between">
-      <Label>{{ t('labels.rememberDestination') }}</Label>
-      <USwitch v-model="form.rememberDestination" />
-    </div>
+    <USwitch v-model="form.overrideSettings" :label="t('labels.overrideSettings')" />
+    <USwitch v-model="form.rememberDestination" :label="t('labels.rememberDestination')" />
 
     <footer class="flex justify-end">
       <Button type="submit" theme="primary" icon="heroicons:arrow-up-tray" :loading>
@@ -99,8 +77,6 @@
 import Alert from '~/components/layout/Alert.vue'
 import Button from '~/components/layout/forms/Button.vue'
 import DocumentationLink from '~/components/layout/DocumentationLink.vue'
-import Label from '~/components/layout/forms/Label.vue'
-import UniqueId from '~/components/UniqueId.vue'
 import {
   useExport,
   useExportDestinations,

--- a/app/components/export/ExportForm.vue
+++ b/app/components/export/ExportForm.vue
@@ -1,0 +1,218 @@
+<template>
+  <form class="max-w-2xl space-y-6" @submit.prevent="submit()">
+    <p class="inline-flex w-full items-center justify-end">
+      <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/export/export-to-a-remote-meilisearch" />
+    </p>
+
+    <Alert v-if="error" dismissable theme="danger" @close="error = null">
+      {{ error }}
+    </Alert>
+
+    <UniqueId as="section" v-slot="{ id }" class="space-y-1">
+      <Label :for="id" required>{{ t('labels.url') }}</Label>
+      <input
+        :id
+        v-model="form.url"
+        type="url"
+        required
+        autofocus
+        list="export-destinations"
+        :placeholder="t('placeholders.url')"
+        class="form-input w-full" />
+      <datalist id="export-destinations">
+        <option v-for="destination of destinations" :key="destination" :value="destination" />
+      </datalist>
+    </UniqueId>
+
+    <UniqueId as="section" v-slot="{ id }" class="space-y-1">
+      <Label :for="id">{{ t('labels.apiKey') }}</Label>
+      <input
+        :id
+        v-model="form.apiKey"
+        type="password"
+        autocomplete="off"
+        :placeholder="t('placeholders.apiKey')"
+        class="form-input w-full" />
+      <p class="text-xs font-light text-gray-500 italic">{{ t('hints.apiKeyNotStored') }}</p>
+    </UniqueId>
+
+    <UniqueId as="section" v-slot="{ id }" class="space-y-1">
+      <Label :for="id">{{ t('labels.payloadSize') }}</Label>
+      <input
+        :id
+        v-model="form.payloadSize"
+        type="text"
+        :placeholder="t('placeholders.payloadSize')"
+        class="form-input w-full" />
+    </UniqueId>
+
+    <section v-if="!indexUid" class="space-y-1">
+      <Label>{{ t('labels.indexes') }}</Label>
+      <UInputMenu
+        v-model="form.selectedIndexes"
+        multiple
+        open-on-click
+        open-on-focus
+        :items="availableIndexes"
+        :placeholder="t('placeholders.indexes')"
+        class="block w-full" />
+      <p class="text-xs font-light text-gray-500 italic">{{ t('hints.allIndexesByDefault') }}</p>
+    </section>
+
+    <UniqueId v-else as="section" v-slot="{ id }" class="space-y-1">
+      <Label :for="id">{{ t('labels.filter') }}</Label>
+      <input :id v-model="form.filter" type="text" :placeholder="t('placeholders.filter')" class="form-input w-full" />
+      <p class="text-xs font-light text-gray-500 italic">{{ t('hints.filter') }}</p>
+    </UniqueId>
+
+    <div class="flex items-center justify-between">
+      <Label>{{ t('labels.overrideSettings') }}</Label>
+      <USwitch v-model="form.overrideSettings" />
+    </div>
+
+    <div class="flex items-center justify-between">
+      <Label>{{ t('labels.rememberDestination') }}</Label>
+      <USwitch v-model="form.rememberDestination" />
+    </div>
+
+    <footer class="flex justify-end">
+      <Button type="submit" theme="primary" icon="heroicons:arrow-up-tray" :loading>
+        {{ t('actions.export') }}
+      </Button>
+    </footer>
+  </form>
+</template>
+
+<script setup lang="ts">
+import Alert from '~/components/layout/Alert.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import UniqueId from '~/components/UniqueId.vue'
+import {
+  useExport,
+  useExportDestinations,
+  useFormSubmit,
+  useMeiliClient,
+  useTask,
+  type ExportPayload,
+} from '~/composables'
+import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, useConfirmationDialog, useToasts } from '~/stores'
+
+type Props = {
+  /** Scope the export to a single index. When omitted, the user picks indexes (or exports all of them). */
+  indexUid?: string
+}
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const meili = useMeiliClient()
+const { exportToRemote } = useExport()
+const { destinations, remember } = useExportDestinations()
+const { confirm } = useConfirmationDialog()
+const { createToast } = useToasts()
+const processTask = useTask()
+const { loading, error, handle } = useFormSubmit()
+
+const form = reactive({
+  url: '',
+  apiKey: '',
+  payloadSize: '',
+  selectedIndexes: [] as string[],
+  filter: '',
+  overrideSettings: false,
+  rememberDestination: false,
+})
+
+// Only needed for the global (non index-scoped) form, to let the user pick indexes.
+const availableIndexes = ref<string[]>([])
+if (!props.indexUid) {
+  const { results } = await meili.getIndexes({ limit: 1000 })
+  availableIndexes.value = results.map((index) => index.uid)
+}
+
+const buildPayload = (): ExportPayload => {
+  const payload: ExportPayload = { url: form.url.trim() }
+  if (form.apiKey) payload.apiKey = form.apiKey
+  if (form.payloadSize.trim()) payload.payloadSize = form.payloadSize.trim()
+
+  const commonOptions = form.overrideSettings ? { overrideSettings: true } : {}
+  if (props.indexUid) {
+    payload.indexes = {
+      [props.indexUid]: { ...commonOptions, ...(form.filter.trim() ? { filter: form.filter.trim() } : {}) },
+    }
+  } else if (form.selectedIndexes.length > 0) {
+    payload.indexes = Object.fromEntries(form.selectedIndexes.map((uid) => [uid, commonOptions]))
+  } else {
+    payload.indexes = { '*': commonOptions }
+  }
+  return payload
+}
+
+const submit = () =>
+  handle(async () => {
+    const destination = form.url.trim()
+    const confirmed = await confirm({
+      title: t('confirmations.export.title'),
+      text: t('confirmations.export.text', { url: destination }),
+      acceptButtonText: t('confirmations.export.acceptButtonText'),
+    })
+    if (!confirmed) {
+      return
+    }
+
+    if (form.rememberDestination) {
+      remember(destination)
+    }
+
+    const toast = createToast({
+      ...TOAST_PLEASEWAIT(t),
+      title: t('toasts.exporting', { url: destination }),
+    })
+    await processTask(() => exportToRemote(buildPayload()), {
+      onSuccess: () => toast.update({ ...TOAST_SUCCESS(t) }),
+      onCanceled: () =>
+        toast.update({
+          ...TOAST_FAILURE(t),
+          text: t('toasts.texts.canceledTask'),
+        }),
+      onFailure: () =>
+        toast.update({
+          ...TOAST_FAILURE(t),
+          text: t('toasts.texts.failedTask'),
+        }),
+    })
+  })
+</script>
+
+<i18n>
+en:
+  labels:
+    url: Destination URL
+    apiKey: Destination API key
+    payloadSize: Payload size (optional)
+    indexes: Indexes
+    filter: Filter (optional)
+    overrideSettings: Override settings on destination
+    rememberDestination: Remember this destination
+  placeholders:
+    url: https://ms-1234.example.com
+    apiKey: Leave empty if not required
+    payloadSize: e.g. 20MiB
+    indexes: All indexes
+    filter: "genres = adventure AND release_date > 1577836800"
+  hints:
+    apiKeyNotStored: Only the destination URL may be remembered below. The API key is never stored and must be
+                      re-entered every time.
+    allIndexesByDefault: Leave empty to export every index.
+    filter: Only documents matching this filter expression will be exported.
+  actions:
+    export: Export
+  confirmations:
+    export:
+      title: Export to a remote instance?
+      text: "This will export data to {url}. Make sure you trust this destination."
+      acceptButtonText: Yes, export
+  toasts:
+    exporting: 'Exporting to {url}...'
+</i18n>

--- a/app/components/layout/TopNavigation.vue
+++ b/app/components/layout/TopNavigation.vue
@@ -138,6 +138,7 @@ import type { DropdownMenuItem } from '@nuxt/ui'
 import { computed, reactive, ref, toRefs } from 'vue'
 import GithubButton from '~/components/layout/GithubButton.vue'
 import LogoutButton from '~/components/layout/LogoutButton.vue'
+import { EXPORT_MIN_VERSION } from '~/composables'
 import { useChatAvailability, useCredentials, useVersion } from '~/stores'
 
 const route = useRoute()
@@ -185,6 +186,12 @@ const navigation = reactive([
     visible: computed(() => chatAvailable.value),
   },
   {
+    name: 'Export',
+    href: '/export',
+    current: computed(() => route.name?.startsWith('export')),
+    visible: computed(() => satisfiesVersion(EXPORT_MIN_VERSION)),
+  },
+  {
     name: 'Experimental',
     href: '/experimental-features',
     current: computed(() => route.name?.startsWith('experimental-features')),
@@ -196,7 +203,7 @@ const visibleNavigation = computed(() => navigation.filter((item) => item.visibl
 
 const { credentials, records, switchInstance, removeInstance: doRemoveInstance } = safeToRefs(useCredentials())
 const { confirm } = useConfirmationDialog()
-const { version } = useVersion()
+const { version, satisfiesVersion } = useVersion()
 const mobileMenuOpen = ref(false)
 const self: any = reactive({
   records,

--- a/app/composables/index.ts
+++ b/app/composables/index.ts
@@ -1,6 +1,7 @@
 export * from './useChatCompletion'
 export * from './useChatWorkspaces'
 export * from './useDateFormatter'
+export * from './useExport'
 export * from './useFields'
 export * from './useFormSubmit'
 export * from './useIndexLocalSettings'

--- a/app/composables/useExport.ts
+++ b/app/composables/useExport.ts
@@ -1,0 +1,52 @@
+import { useLocalStorage } from '@vueuse/core'
+import type { EnqueuedTask } from 'meilisearch'
+import { useMeiliClient } from './useMeiliClient'
+
+export type ExportIndexOptions = {
+  filter?: string
+  overrideSettings?: boolean
+}
+
+export type ExportPayload = {
+  url: string
+  apiKey?: string
+  payloadSize?: string
+  indexes?: Record<string, ExportIndexOptions>
+}
+
+/** Minimum Meilisearch version exposing `POST /export`. */
+export const EXPORT_MIN_VERSION = '>=1.16.0'
+
+/**
+ * `POST /export` (Meilisearch >= 1.16) exports all or part of the instance to a remote
+ * Meilisearch instance. It is not exposed by the JS client yet, so we go through the
+ * public `httpRequest` escape hatch. Going through `useMeiliClient()` keeps reactive
+ * credential switching working.
+ *
+ * @see https://www.meilisearch.com/docs/reference/api/export/export-to-a-remote-meilisearch
+ */
+export const useExport = () => {
+  const meili = useMeiliClient()
+
+  const exportToRemote = (payload: ExportPayload) =>
+    meili.httpRequest.post<EnqueuedTask>({ path: 'export', body: payload })
+
+  return { exportToRemote }
+}
+
+/**
+ * Remembers destination URLs used for past exports, to speed up the form.
+ *
+ * The destination API key is NEVER stored here: it is sensitive and must be re-entered
+ * every time.
+ */
+export const useExportDestinations = () => {
+  const destinations = useLocalStorage<string[]>('export-destinations', [])
+
+  const remember = (url: string) => {
+    if (!url || destinations.value.includes(url)) return
+    destinations.value = [url, ...destinations.value].slice(0, 5)
+  }
+
+  return { destinations, remember }
+}

--- a/app/pages/export.vue
+++ b/app/pages/export.vue
@@ -1,0 +1,29 @@
+<template>
+  <Layout :title="t('title')" :subtitle="t('subtitle')">
+    <Alert v-if="!satisfiesVersion(EXPORT_MIN_VERSION)" theme="warning" :title="t('unavailable.title')">
+      {{ t('unavailable.text') }}
+    </Alert>
+    <ExportForm v-else />
+  </Layout>
+</template>
+
+<script setup lang="ts">
+import Alert from '~/components/layout/Alert.vue'
+import ExportForm from '~/components/export/ExportForm.vue'
+import { EXPORT_MIN_VERSION } from '~/composables'
+import { useVersion } from '~/stores'
+
+const { t } = useI18n()
+const { satisfiesVersion } = useVersion()
+
+useHead({ title: t('title') })
+</script>
+
+<i18n>
+en:
+  title: Export
+  subtitle: Export all or part of this instance to another Meilisearch instance.
+  unavailable:
+    title: Export unavailable
+    text: Exporting to a remote instance requires Meilisearch 1.16 or later.
+</i18n>

--- a/app/pages/indexes/[indexUid]/settings.vue
+++ b/app/pages/indexes/[indexUid]/settings.vue
@@ -26,7 +26,7 @@
 <script setup lang="ts">
 import { NuxtLink, NuxtPage } from '#components'
 import { onMounted } from 'vue'
-import { useMeiliClient } from '~/composables'
+import { EXPORT_MIN_VERSION, useMeiliClient } from '~/composables'
 import { useChatAvailability, useVersion } from '~/stores'
 import { safeToRefs, tryOrThrow } from '~/utils'
 import humanizeString from 'humanize-string'
@@ -140,6 +140,12 @@ const navigation: Array<NavigationItem> = reactive([
     current: computed(() => 'indexes-indexUid-settings-local-settings' === route.name),
     text: t('menu.localSettings'),
   },
+  {
+    href: `/indexes/${index.uid}/settings/export`,
+    current: computed(() => 'indexes-indexUid-settings-export' === route.name),
+    visible: computed(() => satisfiesVersion(EXPORT_MIN_VERSION)),
+    text: t('menu.export'),
+  },
 ])
 
 const visibleNavigation = computed(() => navigation.filter(({ visible }) => visible ?? true))
@@ -175,6 +181,7 @@ en:
     foreignKeys: Foreign Keys
     fields: Fields
     localSettings: Local settings
+    export: Export
   actions:
     documents: Go to Documents
 </i18n>

--- a/app/pages/indexes/[indexUid]/settings/export.vue
+++ b/app/pages/indexes/[indexUid]/settings/export.vue
@@ -1,0 +1,36 @@
+<template>
+  <section class="space-y-4">
+    <h3 class="inline-flex w-full items-center justify-between text-xl font-semibold">
+      {{ t('title') }}
+    </h3>
+
+    <Alert v-if="!satisfiesVersion(EXPORT_MIN_VERSION)" theme="warning" :title="t('unavailable.title')">
+      {{ t('unavailable.text') }}
+    </Alert>
+    <ExportForm v-else :index-uid="indexUid" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import Alert from '~/components/layout/Alert.vue'
+import ExportForm from '~/components/export/ExportForm.vue'
+import { EXPORT_MIN_VERSION } from '~/composables'
+import { useVersion } from '~/stores'
+
+type Props = {
+  indexUid: string
+}
+const props = defineProps<Props>()
+const { t } = useI18n()
+const { satisfiesVersion } = useVersion()
+
+useHead({ title: `${t('title')} - ${props.indexUid}` })
+</script>
+
+<i18n>
+en:
+  title: Export
+  unavailable:
+    title: Export unavailable
+    text: Exporting to a remote instance requires Meilisearch 1.16 or later.
+</i18n>

--- a/app/pages/indexes/index.vue
+++ b/app/pages/indexes/index.vue
@@ -88,8 +88,8 @@
 
 <script setup lang="ts">
 import { tryOrThrow } from '~/utils'
-import { useDateFormatter, useIndexOperations, useMeiliClient, usePagination } from '~/composables'
-import { DismissedDialog } from '~/stores'
+import { EXPORT_MIN_VERSION, useDateFormatter, useIndexOperations, useMeiliClient, usePagination } from '~/composables'
+import { DismissedDialog, useVersion } from '~/stores'
 import { NuxtLink } from '#components'
 import ServerStats from '~/components/settings/ServerStats.vue'
 import Table from '~/components/layout/tables/Table.vue'
@@ -139,6 +139,7 @@ whenever(
   { immediate: true },
 )
 
+const { satisfiesVersion } = useVersion()
 const { duplicateIndex: doDuplicateIndex } = useIndexOperations()
 const duplicateIndex = async (indexUid: string) => {
   const newIndexUid = await doDuplicateIndex(indexUid)
@@ -164,8 +165,6 @@ const swapIndex = async (indexUid: string) => {
 }
 
 const { compactIndex } = useIndexOperations()
-
-const { satisfiesVersion } = useVersion()
 
 const indexMenuItems = (item: Index): DropdownMenuItem[] => [
   {
@@ -194,6 +193,15 @@ const indexMenuItems = (item: Index): DropdownMenuItem[] => [
           label: t('actions.compact'),
           icon: 'heroicons:sparkles',
           onSelect: () => compactIndex(item.uid),
+        },
+      ]
+    : []),
+  ...(satisfiesVersion(EXPORT_MIN_VERSION)
+    ? [
+        {
+          label: t('actions.export'),
+          icon: 'heroicons:arrow-up-tray',
+          to: `/indexes/${item.uid}/settings/export`,
         },
       ]
     : []),
@@ -232,5 +240,6 @@ en:
     rename: Rename
     swap: Swap with…
     compact: Compact
+    export: Export
     openMenu: Open menu
 </i18n>


### PR DESCRIPTION
Adds the Meilisearch **Export API** (`POST /export`, Meilisearch >= 1.16): export all or part of an instance to a remote Meilisearch instance.

## Changes

- **`app/composables/useExport.ts`** (new) — `exportToRemote(payload)` plus `EXPORT_MIN_VERSION`. The JS client 0.59.0 doesn't expose this route, so it goes through the public `meili.httpRequest.post<EnqueuedTask>({ path: 'export', body })` escape hatch — which keeps reactive credential switching working, unlike a hand-rolled `fetch`.
- **`app/components/export/ExportForm.vue`** (new) — the single form used by both entry points.
- **`app/pages/export.vue`** (new) — whole-instance export, reachable from a new **Export** top-menu entry.
- **`app/pages/indexes/[indexUid]/settings/export.vue`** (new) — export scoped to one index, from the index settings nav.
- **`app/pages/indexes/index.vue`** — "Export" entry in the index context menu.

## Payload

`{ url, apiKey?, payloadSize?, indexes: { "<pattern>": { filter?, overrideSettings? } } }`, with optional fields only added when actually filled in. The result is an enqueued task, wrapped with `useTask()` and the usual toast lifecycle.

## Destination credentials 🔒

- The destination API key is a `type="password"` input, is **never** persisted, and never appears in a toast or error message. The form says so explicitly.
- The "remember this destination" option stores the **URL only** (last 5, in localStorage).

## Version gating

Everything is gated on `satisfiesVersion(EXPORT_MIN_VERSION)` — the top-menu entry, the index settings nav entry and the context menu entry all hide below 1.16, and both pages degrade to a warning `Alert` rather than failing.

This also introduces an optional `visible` flag on top-menu entries, which other version-gated features can reuse.

## 🐛 Fixed during review

The `visible` flag was initially applied as `v-if="item.visible ?? true"` on the same element as `v-for="item in navigation"`. In Vue 3 `v-if` is evaluated **before** `v-for` and cannot see the `item` alias, so it compiled to `_ctx.item.visible` on an undefined `item` and threw at render time — taking the whole navigation, and therefore every page, down. Now filtered in a `visibleNavigation` computed instead (last commit).

Worth noting `vue/no-use-v-if-with-v-for` did **not** fire on this, despite `vue/flat/essential` being enabled in `eslint.config.js`. Might be worth a look separately.

## Verification

`yarn format` + `yarn lint` + `yarn run check` clean. **Not exercised against a live instance** — a real cross-instance export needs two running Meilisearch instances, so the payload shape, the `payloadSize` format and the per-index `filter` all need a human to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
