### PR TITLE
Feat: chat workspaces (conversational search)

### DIFF
--- a/app/components/chat/ChatSources.vue
+++ b/app/components/chat/ChatSources.vue
@@ -1,0 +1,41 @@
+<template>
+  <details v-if="documents.length" class="rounded-lg border border-gray-200 bg-gray-50 text-sm">
+    <summary class="cursor-pointer px-3 py-2 text-xs font-medium text-gray-600 hover:text-gray-900">
+      {{ t('summary', { count: documents.length }) }}
+    </summary>
+    <ul class="divide-y divide-gray-200 border-t border-gray-200">
+      <li v-for="(document, index) of documents" :key="index" class="px-3 py-2">
+        <NuxtLink
+          v-if="document.indexUid"
+          :to="`/indexes/${document.indexUid}/documents`"
+          class="text-xs font-semibold text-primary-800 hover:underline">
+          {{ document.indexUid }}
+        </NuxtLink>
+        <pre class="mt-1 overflow-x-auto text-xs whitespace-pre-wrap text-gray-600">{{ preview(document) }}</pre>
+      </li>
+    </ul>
+  </details>
+</template>
+
+<script setup lang="ts">
+import { NuxtLink } from '#components'
+
+/** Shape of one entry in `_meiliSearchSources`; the document itself is arbitrary user data. */
+type ChatSourceDocument = Record<string, any> & { indexUid?: string }
+
+type Props = {
+  documents: ChatSourceDocument[]
+}
+
+const props = defineProps<Props>()
+const { t } = useI18n()
+
+// Documents come straight from the user's index, so their shape is unknown — show the raw
+// JSON rather than guessing which field is a title.
+const preview = (document: ChatSourceDocument) => JSON.stringify(document, null, 2)
+</script>
+
+<i18n>
+en:
+  summary: '{count} source(s) used for this answer'
+</i18n>

--- a/app/components/chat/ChatUnavailableAlert.vue
+++ b/app/components/chat/ChatUnavailableAlert.vue
@@ -1,0 +1,30 @@
+<template>
+  <Alert theme="warning" :title="t('title')">
+    <p v-if="!versionSupported">{{ t('reasons.version', { version: CHAT_MIN_VERSION }) }}</p>
+    <p v-else>
+      {{ t('reasons.experimental') }}
+      <NuxtLink to="/experimental-features" class="font-medium underline">
+        {{ t('actions.enable') }}
+      </NuxtLink>
+    </p>
+  </Alert>
+</template>
+
+<script setup lang="ts">
+import Alert from '~/components/layout/Alert.vue'
+import { CHAT_MIN_VERSION, useChatAvailability } from '~/stores'
+import { safeToRefs } from '~/utils'
+
+const { t } = useI18n()
+const { versionSupported } = safeToRefs(useChatAvailability())
+</script>
+
+<i18n>
+en:
+  title: Conversational search is not available
+  reasons:
+    version: 'Chat workspaces require Meilisearch {version}. This instance runs an older version.'
+    experimental: The chatCompletions experimental feature is disabled on this instance.
+  actions:
+    enable: Enable it in experimental features.
+</i18n>

--- a/app/components/chat/ChatWorkspaceNamePromptModal.vue
+++ b/app/components/chat/ChatWorkspaceNamePromptModal.vue
@@ -1,0 +1,34 @@
+<template>
+  <PromisifiedDialog :title="t('title')" v-slot="{ resolve, close }">
+    <form class="space-y-4" @submit.prevent="resolve(uid)" @reset.prevent="close()">
+      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
+        <Label required :for="id">{{ t('labels.uid') }}</Label>
+        <input v-model="uid" required v-focus autocomplete="off" type="text" class="form-input" />
+        <p class="text-sm font-light text-gray-500">{{ t('hints.uid') }}</p>
+      </UniqueId>
+
+      <Buttons>
+        <Button type="submit" />
+      </Buttons>
+    </form>
+  </PromisifiedDialog>
+</template>
+
+<script setup lang="ts">
+import PromisifiedDialog from '~/components/layout/dialogs/PromisifiedDialog.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+import Label from '~/components/layout/forms/Label.vue'
+
+const { t } = useI18n()
+const uid = ref('')
+</script>
+
+<i18n>
+en:
+  title: New chat workspace
+  labels:
+    uid: Workspace name
+  hints:
+    uid: The workspace is created once you save its settings.
+</i18n>

--- a/app/components/chat/ChatWorkspaceNamePromptModal.vue
+++ b/app/components/chat/ChatWorkspaceNamePromptModal.vue
@@ -1,11 +1,9 @@
 <template>
   <PromisifiedDialog :title="t('title')" v-slot="{ resolve, close }">
     <form class="space-y-4" @submit.prevent="resolve(uid)" @reset.prevent="close()">
-      <UniqueId as="section" v-slot="{ id }" class="flex flex-col gap-1">
-        <Label required :for="id">{{ t('labels.uid') }}</Label>
-        <input v-model="uid" required v-focus autocomplete="off" type="text" class="form-input" />
-        <p class="text-sm font-light text-gray-500">{{ t('hints.uid') }}</p>
-      </UniqueId>
+      <UFormField :label="t('labels.uid')" :help="t('hints.uid')" required>
+        <UInput v-model="uid" required v-focus autocomplete="off" class="w-full" />
+      </UFormField>
 
       <Buttons>
         <Button type="submit" />
@@ -18,7 +16,6 @@
 import PromisifiedDialog from '~/components/layout/dialogs/PromisifiedDialog.vue'
 import Button from '~/components/layout/forms/Button.vue'
 import Buttons from '~/components/layout/forms/Buttons.vue'
-import Label from '~/components/layout/forms/Label.vue'
 
 const { t } = useI18n()
 const uid = ref('')

--- a/app/components/chat/ChatWorkspaceSettingsForm.vue
+++ b/app/components/chat/ChatWorkspaceSettingsForm.vue
@@ -49,27 +49,27 @@
 
       <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
         <Label :for="id">{{ t('labels.prompts.system') }}</Label>
-        <Textarea :id v-model="form.prompts.system" class="w-full text-sm" rows="6" />
+        <Textarea :id v-model="form.prompts.system" class="w-full text-sm" :rows="6" />
       </UniqueId>
 
       <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
         <Label :for="id">{{ t('labels.prompts.searchDescription') }}</Label>
-        <Textarea :id v-model="form.prompts.searchDescription" class="w-full text-sm" rows="3" />
+        <Textarea :id v-model="form.prompts.searchDescription" class="w-full text-sm" :rows="3" />
       </UniqueId>
 
       <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
         <Label :for="id">{{ t('labels.prompts.searchQParam') }}</Label>
-        <Textarea :id v-model="form.prompts.searchQParam" class="w-full text-sm" rows="2" />
+        <Textarea :id v-model="form.prompts.searchQParam" class="w-full text-sm" :rows="2" />
       </UniqueId>
 
       <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
         <Label :for="id">{{ t('labels.prompts.searchFilterParam') }}</Label>
-        <Textarea :id v-model="form.prompts.searchFilterParam" class="w-full text-sm" rows="2" />
+        <Textarea :id v-model="form.prompts.searchFilterParam" class="w-full text-sm" :rows="2" />
       </UniqueId>
 
       <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
         <Label :for="id">{{ t('labels.prompts.searchIndexUidParam') }}</Label>
-        <Textarea :id v-model="form.prompts.searchIndexUidParam" class="w-full text-sm" rows="2" />
+        <Textarea :id v-model="form.prompts.searchIndexUidParam" class="w-full text-sm" :rows="2" />
       </UniqueId>
     </section>
 

--- a/app/components/chat/ChatWorkspaceSettingsForm.vue
+++ b/app/components/chat/ChatWorkspaceSettingsForm.vue
@@ -1,0 +1,239 @@
+<template>
+  <form class="max-w-2xl space-y-8" @reset.prevent="reset()" @submit.prevent="submit()">
+    <Alert v-if="error" dismissable theme="danger" @close="error = null">
+      {{ error }}
+    </Alert>
+
+    <section class="space-y-4">
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label required :for="id">{{ t('labels.source') }}</Label>
+        <Select :id v-model="form.source" required class="w-full">
+          <option v-for="source of CHAT_SOURCES" :key="source" :value="source">{{ sourceLabels[source] }}</option>
+        </Select>
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :required="'vLlm' === form.source" :for="id">{{ t('labels.baseUrl') }}</Label>
+        <input
+          :id
+          v-model="form.baseUrl"
+          :required="'vLlm' === form.source"
+          autocomplete="off"
+          type="url"
+          :placeholder="t('placeholders.baseUrl')"
+          class="form-input w-full text-sm" />
+        <p class="text-sm font-light text-gray-500">{{ t('hints.baseUrl') }}</p>
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.apiKey') }}</Label>
+        <input
+          :id
+          v-model="form.apiKey"
+          autocomplete="off"
+          type="password"
+          :placeholder="t('placeholders.apiKey')"
+          class="form-input w-full text-sm" />
+        <p class="text-sm font-light text-gray-500">{{ t('hints.apiKey') }}</p>
+      </UniqueId>
+
+      <OpenAiChatSourceForm v-if="'openAi' === form.source" v-model="form" />
+      <AzureOpenAiChatSourceForm v-if="'azureOpenAi' === form.source" v-model="form" />
+    </section>
+
+    <section class="space-y-4">
+      <div>
+        <h3 class="text-lg font-semibold">{{ t('sections.prompts') }}</h3>
+        <p class="text-sm font-light text-gray-500">{{ t('hints.prompts') }}</p>
+      </div>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.prompts.system') }}</Label>
+        <Textarea :id v-model="form.prompts.system" class="w-full text-sm" rows="6" />
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.prompts.searchDescription') }}</Label>
+        <Textarea :id v-model="form.prompts.searchDescription" class="w-full text-sm" rows="3" />
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.prompts.searchQParam') }}</Label>
+        <Textarea :id v-model="form.prompts.searchQParam" class="w-full text-sm" rows="2" />
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.prompts.searchFilterParam') }}</Label>
+        <Textarea :id v-model="form.prompts.searchFilterParam" class="w-full text-sm" rows="2" />
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+        <Label :for="id">{{ t('labels.prompts.searchIndexUidParam') }}</Label>
+        <Textarea :id v-model="form.prompts.searchIndexUidParam" class="w-full text-sm" rows="2" />
+      </UniqueId>
+    </section>
+
+    <footer class="flex flex-col items-center justify-between gap-2 sm:flex-row">
+      <Button type="button" icon="mdi:backup-restore" :disabled="loading" @click="resetToDefaults()">
+        {{ t('actions.resetToDefaults') }}
+      </Button>
+      <Buttons>
+        <Button type="reset" :disabled="loading" />
+        <Button type="submit" :disabled="loading" :loading />
+      </Buttons>
+    </footer>
+  </form>
+</template>
+
+<script setup lang="ts">
+import UniqueId from '~/components/UniqueId.vue'
+import AzureOpenAiChatSourceForm from '~/components/chat/source/AzureOpenAiChatSourceForm.vue'
+import OpenAiChatSourceForm from '~/components/chat/source/OpenAiChatSourceForm.vue'
+import Alert from '~/components/layout/Alert.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import Select from '~/components/layout/forms/Select.vue'
+import Textarea from '~/components/layout/forms/Textarea.vue'
+import { CHAT_SOURCES, useChatWorkspaces, useFormSubmit, type ChatWorkspaceSettings } from '~/composables'
+import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, useConfirmationDialog, useToasts } from '~/stores'
+
+type Props = {
+  uid: string
+  settings: ChatWorkspaceSettings
+}
+const props = defineProps<Props>()
+const emit = defineEmits<{ saved: [settings: ChatWorkspaceSettings] }>()
+
+const { t } = useI18n()
+const { updateSettings, resetSettings, getSettings } = useChatWorkspaces()
+const { confirm } = useConfirmationDialog()
+const { createToast } = useToasts()
+const { loading, error, handle } = useFormSubmit()
+
+const sourceLabels: Record<string, string> = {
+  openAi: 'OpenAI',
+  azureOpenAi: 'Azure OpenAI',
+  mistral: 'Mistral',
+  gemini: 'Gemini',
+  vLlm: 'vLLM',
+}
+
+/**
+ * The API key is never prefilled: Meilisearch redacts it when reading the settings back, so
+ * echoing it would either leak a masked value into the payload or overwrite the real secret.
+ * An empty field means "keep the current key".
+ */
+const factory = () => ({
+  source: props.settings.source ?? 'openAi',
+  baseUrl: props.settings.baseUrl ?? '',
+  apiKey: '',
+  orgId: props.settings.orgId ?? '',
+  projectId: props.settings.projectId ?? '',
+  deploymentId: props.settings.deploymentId ?? '',
+  apiVersion: props.settings.apiVersion ?? '',
+  prompts: {
+    system: props.settings.prompts?.system ?? '',
+    searchDescription: props.settings.prompts?.searchDescription ?? '',
+    searchQParam: props.settings.prompts?.searchQParam ?? '',
+    searchFilterParam: props.settings.prompts?.searchFilterParam ?? '',
+    searchIndexUidParam: props.settings.prompts?.searchIndexUidParam ?? '',
+  },
+})
+
+// A `ref` (rather than `reactive`) so the source sub-forms can take it through `v-model`
+// without the compiler having to rewrite a const binding.
+const form = ref(factory())
+const reset = () => (form.value = factory())
+
+/** PATCH semantics: an omitted field keeps its value, an explicit `null` resets it to default. */
+const orNull = (value: string) => (value.trim().length ? value.trim() : null)
+
+const payload = () => {
+  const { source, baseUrl, apiKey, orgId, projectId, deploymentId, apiVersion, prompts } = form.value
+  const body: Partial<ChatWorkspaceSettings> = {
+    source,
+    baseUrl: orNull(baseUrl),
+    // Fields that don't apply to the selected source are reset rather than left dangling.
+    orgId: 'openAi' === source ? orNull(orgId) : null,
+    projectId: 'openAi' === source ? orNull(projectId) : null,
+    deploymentId: 'azureOpenAi' === source ? orNull(deploymentId) : null,
+    apiVersion: 'azureOpenAi' === source ? orNull(apiVersion) : null,
+    prompts: {
+      system: orNull(prompts.system),
+      searchDescription: orNull(prompts.searchDescription),
+      searchQParam: orNull(prompts.searchQParam),
+      searchFilterParam: orNull(prompts.searchFilterParam),
+      searchIndexUidParam: orNull(prompts.searchIndexUidParam),
+    },
+  }
+  if (apiKey.trim()) {
+    body.apiKey = apiKey.trim()
+  }
+  return body
+}
+
+const submit = () =>
+  handle(async () => {
+    const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: t('toasts.saving') })
+    try {
+      const settings = await updateSettings(props.uid, payload())
+      toast.update({ ...TOAST_SUCCESS(t) })
+      emit('saved', settings)
+      form.value.apiKey = ''
+    } catch (e) {
+      toast.update({ ...TOAST_FAILURE(t) })
+      throw e
+    }
+  })
+
+const resetToDefaults = () =>
+  handle(async () => {
+    if (!(await confirm({ text: t('confirmations.resetToDefaults') }))) {
+      return
+    }
+    const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: t('toasts.resetting') })
+    try {
+      await resetSettings(props.uid)
+      // The reset endpoint answers 204, so read the defaults back to refresh the form.
+      emit('saved', await getSettings(props.uid))
+      toast.update({ ...TOAST_SUCCESS(t) })
+    } catch (e) {
+      toast.update({ ...TOAST_FAILURE(t) })
+      throw e
+    }
+  })
+
+// Re-seed the form whenever the page hands over freshly loaded settings.
+watch(() => props.settings, reset)
+</script>
+
+<i18n>
+en:
+  sections:
+    prompts: Prompts
+  labels:
+    source: LLM source
+    baseUrl: Base URL
+    apiKey: API key
+    prompts:
+      system: System prompt
+      searchDescription: Search tool description
+      searchQParam: Search query parameter description
+      searchFilterParam: Search filter parameter description
+      searchIndexUidParam: Search index parameter description
+  placeholders:
+    baseUrl: https://api.openai.com/v1
+    apiKey: Leave blank to keep the current key
+  hints:
+    baseUrl: Overrides the provider default. Required for self-hosted vLLM.
+    apiKey: Stored by Meilisearch and redacted when read back, so it is never prefilled here.
+    prompts: Leave a field empty to fall back to the Meilisearch default prompt.
+  actions:
+    resetToDefaults: Reset to defaults
+  confirmations:
+    resetToDefaults: Do you really want to reset every setting of this workspace, including its API key?
+  toasts:
+    saving: Saving settings...
+    resetting: Resetting settings...
+</i18n>

--- a/app/components/chat/ChatWorkspaceSettingsForm.vue
+++ b/app/components/chat/ChatWorkspaceSettingsForm.vue
@@ -5,37 +5,28 @@
     </Alert>
 
     <section class="space-y-4">
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label required :for="id">{{ t('labels.source') }}</Label>
-        <Select :id v-model="form.source" required class="w-full">
-          <option v-for="source of CHAT_SOURCES" :key="source" :value="source">{{ sourceLabels[source] }}</option>
-        </Select>
-      </UniqueId>
+      <UFormField :label="t('labels.source')" required>
+        <USelect v-model="form.source" :items="sourceItems" required class="w-full" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :required="'vLlm' === form.source" :for="id">{{ t('labels.baseUrl') }}</Label>
-        <input
-          :id
+      <UFormField :label="t('labels.baseUrl')" :help="t('hints.baseUrl')" :required="'vLlm' === form.source">
+        <UInput
           v-model="form.baseUrl"
           :required="'vLlm' === form.source"
           autocomplete="off"
           type="url"
           :placeholder="t('placeholders.baseUrl')"
-          class="form-input w-full text-sm" />
-        <p class="text-sm font-light text-gray-500">{{ t('hints.baseUrl') }}</p>
-      </UniqueId>
+          class="w-full" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :for="id">{{ t('labels.apiKey') }}</Label>
-        <input
-          :id
+      <UFormField :label="t('labels.apiKey')" :help="t('hints.apiKey')">
+        <UInput
           v-model="form.apiKey"
           autocomplete="off"
           type="password"
           :placeholder="t('placeholders.apiKey')"
-          class="form-input w-full text-sm" />
-        <p class="text-sm font-light text-gray-500">{{ t('hints.apiKey') }}</p>
-      </UniqueId>
+          class="w-full" />
+      </UFormField>
 
       <OpenAiChatSourceForm v-if="'openAi' === form.source" v-model="form" />
       <AzureOpenAiChatSourceForm v-if="'azureOpenAi' === form.source" v-model="form" />
@@ -47,30 +38,25 @@
         <p class="text-sm font-light text-gray-500">{{ t('hints.prompts') }}</p>
       </div>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :for="id">{{ t('labels.prompts.system') }}</Label>
-        <Textarea :id v-model="form.prompts.system" class="w-full text-sm" :rows="6" />
-      </UniqueId>
+      <UFormField :label="t('labels.prompts.system')">
+        <UTextarea v-model="form.prompts.system" class="w-full" :rows="6" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :for="id">{{ t('labels.prompts.searchDescription') }}</Label>
-        <Textarea :id v-model="form.prompts.searchDescription" class="w-full text-sm" :rows="3" />
-      </UniqueId>
+      <UFormField :label="t('labels.prompts.searchDescription')">
+        <UTextarea v-model="form.prompts.searchDescription" class="w-full" :rows="3" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :for="id">{{ t('labels.prompts.searchQParam') }}</Label>
-        <Textarea :id v-model="form.prompts.searchQParam" class="w-full text-sm" :rows="2" />
-      </UniqueId>
+      <UFormField :label="t('labels.prompts.searchQParam')">
+        <UTextarea v-model="form.prompts.searchQParam" class="w-full" :rows="2" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :for="id">{{ t('labels.prompts.searchFilterParam') }}</Label>
-        <Textarea :id v-model="form.prompts.searchFilterParam" class="w-full text-sm" :rows="2" />
-      </UniqueId>
+      <UFormField :label="t('labels.prompts.searchFilterParam')">
+        <UTextarea v-model="form.prompts.searchFilterParam" class="w-full" :rows="2" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-        <Label :for="id">{{ t('labels.prompts.searchIndexUidParam') }}</Label>
-        <Textarea :id v-model="form.prompts.searchIndexUidParam" class="w-full text-sm" :rows="2" />
-      </UniqueId>
+      <UFormField :label="t('labels.prompts.searchIndexUidParam')">
+        <UTextarea v-model="form.prompts.searchIndexUidParam" class="w-full" :rows="2" />
+      </UFormField>
     </section>
 
     <footer class="flex flex-col items-center justify-between gap-2 sm:flex-row">
@@ -86,15 +72,11 @@
 </template>
 
 <script setup lang="ts">
-import UniqueId from '~/components/UniqueId.vue'
 import AzureOpenAiChatSourceForm from '~/components/chat/source/AzureOpenAiChatSourceForm.vue'
 import OpenAiChatSourceForm from '~/components/chat/source/OpenAiChatSourceForm.vue'
 import Alert from '~/components/layout/Alert.vue'
 import Button from '~/components/layout/forms/Button.vue'
 import Buttons from '~/components/layout/forms/Buttons.vue'
-import Label from '~/components/layout/forms/Label.vue'
-import Select from '~/components/layout/forms/Select.vue'
-import Textarea from '~/components/layout/forms/Textarea.vue'
 import { CHAT_SOURCES, useChatWorkspaces, useFormSubmit, type ChatWorkspaceSettings } from '~/composables'
 import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, useConfirmationDialog, useToasts } from '~/stores'
 
@@ -118,6 +100,7 @@ const sourceLabels: Record<string, string> = {
   gemini: 'Gemini',
   vLlm: 'vLLM',
 }
+const sourceItems = CHAT_SOURCES.map((source) => ({ label: sourceLabels[source], value: source }))
 
 /**
  * The API key is never prefilled: Meilisearch redacts it when reading the settings back, so

--- a/app/components/chat/source/AzureOpenAiChatSourceForm.vue
+++ b/app/components/chat/source/AzureOpenAiChatSourceForm.vue
@@ -1,23 +1,18 @@
 <template>
-  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-    <Label :for="id">{{ t('labels.deploymentId') }}</Label>
-    <input :id v-model="settings!.deploymentId" autocomplete="off" type="text" class="form-input w-full text-sm" />
-  </UniqueId>
+  <UFormField :label="t('labels.deploymentId')">
+    <UInput v-model="settings!.deploymentId" autocomplete="off" class="w-full" />
+  </UFormField>
 
-  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-    <Label :for="id">{{ t('labels.apiVersion') }}</Label>
-    <input
-      :id
+  <UFormField :label="t('labels.apiVersion')">
+    <UInput
       v-model="settings!.apiVersion"
       autocomplete="off"
-      type="text"
       :placeholder="t('placeholders.apiVersion')"
-      class="form-input w-full text-sm" />
-  </UniqueId>
+      class="w-full" />
+  </UFormField>
 </template>
 
 <script setup lang="ts">
-import Label from '~/components/layout/forms/Label.vue'
 import type { ChatWorkspaceSettings } from '~/composables'
 
 const settings = defineModel<ChatWorkspaceSettings>()

--- a/app/components/chat/source/AzureOpenAiChatSourceForm.vue
+++ b/app/components/chat/source/AzureOpenAiChatSourceForm.vue
@@ -1,0 +1,34 @@
+<template>
+  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+    <Label :for="id">{{ t('labels.deploymentId') }}</Label>
+    <input :id v-model="settings!.deploymentId" autocomplete="off" type="text" class="form-input w-full text-sm" />
+  </UniqueId>
+
+  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+    <Label :for="id">{{ t('labels.apiVersion') }}</Label>
+    <input
+      :id
+      v-model="settings!.apiVersion"
+      autocomplete="off"
+      type="text"
+      :placeholder="t('placeholders.apiVersion')"
+      class="form-input w-full text-sm" />
+  </UniqueId>
+</template>
+
+<script setup lang="ts">
+import Label from '~/components/layout/forms/Label.vue'
+import type { ChatWorkspaceSettings } from '~/composables'
+
+const settings = defineModel<ChatWorkspaceSettings>()
+const { t } = useI18n()
+</script>
+
+<i18n>
+en:
+  labels:
+    deploymentId: Deployment ID
+    apiVersion: API version
+  placeholders:
+    apiVersion: 2024-06-01
+</i18n>

--- a/app/components/chat/source/OpenAiChatSourceForm.vue
+++ b/app/components/chat/source/OpenAiChatSourceForm.vue
@@ -1,17 +1,14 @@
 <template>
-  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-    <Label :for="id">{{ t('labels.orgId') }}</Label>
-    <input :id v-model="settings!.orgId" autocomplete="off" type="text" class="form-input w-full text-sm" />
-  </UniqueId>
+  <UFormField :label="t('labels.orgId')">
+    <UInput v-model="settings!.orgId" autocomplete="off" class="w-full" />
+  </UFormField>
 
-  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
-    <Label :for="id">{{ t('labels.projectId') }}</Label>
-    <input :id v-model="settings!.projectId" autocomplete="off" type="text" class="form-input w-full text-sm" />
-  </UniqueId>
+  <UFormField :label="t('labels.projectId')">
+    <UInput v-model="settings!.projectId" autocomplete="off" class="w-full" />
+  </UFormField>
 </template>
 
 <script setup lang="ts">
-import Label from '~/components/layout/forms/Label.vue'
 import type { ChatWorkspaceSettings } from '~/composables'
 
 const settings = defineModel<ChatWorkspaceSettings>()

--- a/app/components/chat/source/OpenAiChatSourceForm.vue
+++ b/app/components/chat/source/OpenAiChatSourceForm.vue
@@ -1,0 +1,26 @@
+<template>
+  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+    <Label :for="id">{{ t('labels.orgId') }}</Label>
+    <input :id v-model="settings!.orgId" autocomplete="off" type="text" class="form-input w-full text-sm" />
+  </UniqueId>
+
+  <UniqueId v-slot="{ id }" as="section" class="flex flex-col gap-1">
+    <Label :for="id">{{ t('labels.projectId') }}</Label>
+    <input :id v-model="settings!.projectId" autocomplete="off" type="text" class="form-input w-full text-sm" />
+  </UniqueId>
+</template>
+
+<script setup lang="ts">
+import Label from '~/components/layout/forms/Label.vue'
+import type { ChatWorkspaceSettings } from '~/composables'
+
+const settings = defineModel<ChatWorkspaceSettings>()
+const { t } = useI18n()
+</script>
+
+<i18n>
+en:
+  labels:
+    orgId: Organization ID
+    projectId: Project ID
+</i18n>

--- a/app/components/layout/TopNavigation.vue
+++ b/app/components/layout/TopNavigation.vue
@@ -94,7 +94,7 @@
         </div>
         <nav class="hidden lg:flex lg:space-x-8 lg:py-2" aria-label="Global">
           <NuxtLink
-            v-for="item in navigation"
+            v-for="item in visibleNavigation"
             :key="item.name"
             :to="item.href"
             :class="[
@@ -110,7 +110,7 @@
       <nav v-if="mobileMenuOpen" class="lg:hidden" aria-label="Global">
         <div class="mx-auto max-w-3xl space-y-1 px-2 pt-2 pb-3 sm:px-4">
           <NuxtLink
-            v-for="item in navigation"
+            v-for="item in visibleNavigation"
             :key="item.name"
             :to="item.href"
             :aria-current="item.current ? 'page' : undefined"
@@ -138,9 +138,10 @@ import type { DropdownMenuItem } from '@nuxt/ui'
 import { computed, reactive, ref, toRefs } from 'vue'
 import GithubButton from '~/components/layout/GithubButton.vue'
 import LogoutButton from '~/components/layout/LogoutButton.vue'
-import { useCredentials, useVersion } from '~/stores'
+import { useChatAvailability, useCredentials, useVersion } from '~/stores'
 
 const route = useRoute()
+const { available: chatAvailable } = safeToRefs(useChatAvailability())
 const navigation = reactive([
   {
     name: 'Indexes',
@@ -178,11 +179,20 @@ const navigation = reactive([
     current: computed(() => route.name?.startsWith('search-rules')),
   },
   {
+    name: 'Chat',
+    href: '/chat',
+    current: computed(() => route.name?.startsWith('chat')),
+    visible: computed(() => chatAvailable.value),
+  },
+  {
     name: 'Experimental',
     href: '/experimental-features',
     current: computed(() => route.name?.startsWith('experimental-features')),
   },
 ])
+
+// Entries without a `visible` flag are always shown.
+const visibleNavigation = computed(() => navigation.filter((item) => item.visible ?? true))
 
 const { credentials, records, switchInstance, removeInstance: doRemoveInstance } = safeToRefs(useCredentials())
 const { confirm } = useConfirmationDialog()

--- a/app/composables/index.ts
+++ b/app/composables/index.ts
@@ -1,3 +1,4 @@
+export * from './useChatWorkspaces'
 export * from './useDateFormatter'
 export * from './useFields'
 export * from './useFormSubmit'

--- a/app/composables/index.ts
+++ b/app/composables/index.ts
@@ -1,3 +1,4 @@
+export * from './useChatCompletion'
 export * from './useChatWorkspaces'
 export * from './useDateFormatter'
 export * from './useFields'

--- a/app/composables/useChatCompletion.ts
+++ b/app/composables/useChatCompletion.ts
@@ -1,0 +1,167 @@
+import { tryOnScopeDispose } from '@vueuse/core'
+import { CHAT_TOOLS, useChatWorkspaces, type ChatMessage } from './useChatWorkspaces'
+
+/** One entry of `_meiliSearchSources`; the document itself is arbitrary user data. */
+export type ChatSourceDocument = Record<string, any> & { indexUid?: string }
+
+export type ChatTurn = {
+  role: 'user' | 'assistant'
+  content: string
+  /** Documents Meilisearch used to ground this answer, streamed through `_meiliSearchSources`. */
+  sources: ChatSourceDocument[]
+  /** Latest `_meiliSearchProgress` message, cleared once the answer starts coming in. */
+  progress: string | null
+}
+
+type OpenAiDelta = {
+  content?: string | null
+  tool_calls?: Array<{
+    index?: number
+    function?: { name?: string; arguments?: string }
+  }>
+}
+
+/**
+ * Drives one conversation against `POST /chats/{workspace}/chat/completions`.
+ *
+ * The route speaks the OpenAI streaming protocol: SSE frames carrying
+ * `choices[0].delta`, terminated by a `data: [DONE]` sentinel. On top of that, Meilisearch
+ * calls back two tools — `_meiliSearchProgress` while it searches, `_meiliSearchSources`
+ * with the documents it grounded the answer on — but only if the request declares them,
+ * which is why {@link CHAT_TOOLS} is always sent.
+ *
+ * Tool call `arguments` arrive in fragments that have to be concatenated per tool call
+ * before they parse as JSON.
+ */
+export const useChatCompletion = (workspace: string) => {
+  const { streamCompletion } = useChatWorkspaces()
+
+  const self = reactive({
+    turns: [] as ChatTurn[],
+    streaming: false,
+    error: null as string | null,
+  })
+
+  let controller: AbortController | null = null
+
+  const stop = () => {
+    controller?.abort()
+    controller = null
+    self.streaming = false
+  }
+
+  // Abort on unmount, on navigation away and on instance switch (`app.vue`'s pageKey
+  // remounts the page), so a half-read stream never outlives the component.
+  tryOnScopeDispose(stop)
+
+  const applyDelta = (turn: ChatTurn, delta: OpenAiDelta, toolArguments: Map<number, string>) => {
+    if (delta.content) {
+      turn.content += delta.content
+      // The answer has started, so whatever the search was reporting is now stale.
+      turn.progress = null
+    }
+
+    for (const [position, call] of (delta.tool_calls ?? []).entries()) {
+      const index = call.index ?? position
+      const name = call.function?.name
+      const buffered = (toolArguments.get(index) ?? '') + (call.function?.arguments ?? '')
+      toolArguments.set(index, buffered)
+
+      let parsed: any
+      try {
+        parsed = JSON.parse(buffered)
+      } catch {
+        // Arguments are still arriving in fragments — wait for the rest.
+        continue
+      }
+
+      if ('_meiliSearchSources' === name) {
+        turn.sources = Array.isArray(parsed) ? parsed : parsed?.sources ?? []
+      } else if ('_meiliSearchProgress' === name) {
+        turn.progress = parsed?.message ?? parsed?.status ?? null
+      }
+      toolArguments.delete(index)
+    }
+  }
+
+  /** An SSE frame is a set of lines; only its (possibly multi-line) `data:` payload matters. */
+  const payloadOf = (frame: string) =>
+    frame
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice('data:'.length).trimStart())
+      .join('\n')
+
+  const send = async (prompt: string, model: string) => {
+    if (self.streaming || !prompt.trim()) {
+      return
+    }
+
+    self.error = null
+    self.turns.push({ role: 'user', content: prompt.trim(), sources: [], progress: null })
+    const turn: ChatTurn = { role: 'assistant', content: '', sources: [], progress: null }
+    self.turns.push(turn)
+
+    // History is sent verbatim, minus our own display-only fields.
+    const messages: ChatMessage[] = self.turns
+      .filter((candidate) => candidate !== turn)
+      .map(({ role, content }) => ({ role, content }))
+
+    controller = new AbortController()
+    self.streaming = true
+
+    try {
+      const body = await streamCompletion(
+        workspace,
+        { model, messages, stream: true, tools: CHAT_TOOLS },
+        controller.signal,
+      )
+      const reader = body.pipeThrough(new TextDecoderStream()).getReader()
+      const toolArguments = new Map<number, string>()
+      let buffer = ''
+
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        buffer = (buffer + value).replaceAll('\r\n', '\n')
+        // Frames are separated by a blank line; a chunk may hold several, or half of one.
+        let boundary = buffer.indexOf('\n\n')
+        while (-1 !== boundary) {
+          const data = payloadOf(buffer.slice(0, boundary))
+          buffer = buffer.slice(boundary + 2)
+          boundary = buffer.indexOf('\n\n')
+
+          if ('' === data || '[DONE]' === data) {
+            continue
+          }
+          try {
+            applyDelta(turn, JSON.parse(data)?.choices?.[0]?.delta ?? {}, toolArguments)
+          } catch {
+            // A malformed frame must not tear down an otherwise healthy answer.
+          }
+        }
+      }
+    } catch (e: any) {
+      // Aborting is a user action ("stop"), not a failure worth reporting.
+      if ('AbortError' !== e?.name) {
+        self.error = e?.message ?? String(e)
+      }
+    } finally {
+      self.streaming = false
+      controller = null
+      turn.progress = null
+    }
+  }
+
+  const clear = () => {
+    stop()
+    self.turns = []
+    self.error = null
+  }
+
+  const { turns, streaming, error } = toRefs(self)
+
+  return { turns, streaming, error, send, stop, clear }
+}

--- a/app/composables/useChatCompletion.ts
+++ b/app/composables/useChatCompletion.ts
@@ -1,4 +1,5 @@
 import { tryOnScopeDispose } from '@vueuse/core'
+import type { MaybeRef } from 'vue'
 import { CHAT_TOOLS, useChatWorkspaces, type ChatMessage } from './useChatWorkspaces'
 
 /** One entry of `_meiliSearchSources`; the document itself is arbitrary user data. */
@@ -43,9 +44,11 @@ type OpenAiDelta = {
  *
  * Tool call `arguments` arrive in fragments that have to be concatenated per tool call
  * before they parse as JSON.
+ *
+ * @param accessKey Optional key the completions run under, see {@link useChatWorkspaces}.
  */
-export const useChatCompletion = (workspace: string) => {
-  const { streamCompletion } = useChatWorkspaces()
+export const useChatCompletion = (workspace: string, accessKey?: MaybeRef<string>) => {
+  const { streamCompletion } = useChatWorkspaces(accessKey)
 
   const self = reactive({
     turns: [] as ChatTurn[],

--- a/app/composables/useChatCompletion.ts
+++ b/app/composables/useChatCompletion.ts
@@ -166,7 +166,14 @@ export const useChatCompletion = (workspace: string) => {
             continue
           }
           try {
-            applyDelta(turn, JSON.parse(data)?.choices?.[0]?.delta ?? {}, toolArguments)
+            const frame = JSON.parse(data)
+            // The provider's own failures (invalid key, quota, unknown model) reach us as an
+            // SSE frame on an otherwise 200 response, so they have to be surfaced explicitly.
+            if ('error' === frame?.type) {
+              self.error = frame.error?.message ?? data
+              continue
+            }
+            applyDelta(turn, frame?.choices?.[0]?.delta ?? {}, toolArguments)
           } catch {
             // A malformed frame must not tear down an otherwise healthy answer.
           }
@@ -181,6 +188,11 @@ export const useChatCompletion = (workspace: string) => {
       self.streaming = false
       controller = null
       turn.progress = null
+      // A turn that never received anything (provider error, stopped straight away) would
+      // otherwise linger as an empty bubble.
+      if (!turn.content && !turn.sources.length) {
+        self.turns.splice(self.turns.indexOf(turn), 1)
+      }
     }
   }
 

--- a/app/composables/useChatCompletion.ts
+++ b/app/composables/useChatCompletion.ts
@@ -4,13 +4,24 @@ import { CHAT_TOOLS, useChatWorkspaces, type ChatMessage } from './useChatWorksp
 /** One entry of `_meiliSearchSources`; the document itself is arbitrary user data. */
 export type ChatSourceDocument = Record<string, any> & { indexUid?: string }
 
+/**
+ * Structured view of a `_meiliSearchProgress` call: Meilisearch reports which index it is
+ * currently searching, with which query and filter. Handed up structured rather than
+ * pre-formatted so the component can translate it via its own `<i18n>` block.
+ */
+export type ChatProgress = {
+  indexUid: string
+  query: string
+  filter: string
+}
+
 export type ChatTurn = {
   role: 'user' | 'assistant'
   content: string
   /** Documents Meilisearch used to ground this answer, streamed through `_meiliSearchSources`. */
   sources: ChatSourceDocument[]
-  /** Latest `_meiliSearchProgress` message, cleared once the answer starts coming in. */
-  progress: string | null
+  /** Latest `_meiliSearchProgress` call, cleared once the answer starts coming in. */
+  progress: ChatProgress | null
 }
 
 type OpenAiDelta = {
@@ -54,6 +65,23 @@ export const useChatCompletion = (workspace: string) => {
   // remounts the page), so a half-read stream never outlives the component.
   tryOnScopeDispose(stop)
 
+  /**
+   * `_meiliSearchProgress`'s own arguments wrap a second, independently-serialized JSON
+   * string in `function_arguments` (e.g. `_meiliSearchInIndex` with `{index_uid, q, filter}`).
+   * That inner parse must not tear down the stream if Meilisearch ever changes the shape.
+   */
+  const parseProgress = (call: { function_name?: string; function_arguments?: string }): ChatProgress | null => {
+    if ('_meiliSearchInIndex' !== call.function_name) {
+      return null
+    }
+    try {
+      const args = JSON.parse(call.function_arguments ?? '{}')
+      return { indexUid: args.index_uid ?? '', query: args.q ?? '', filter: args.filter ?? '' }
+    } catch {
+      return null
+    }
+  }
+
   const applyDelta = (turn: ChatTurn, delta: OpenAiDelta, toolArguments: Map<number, string>) => {
     if (delta.content) {
       turn.content += delta.content
@@ -76,9 +104,10 @@ export const useChatCompletion = (workspace: string) => {
       }
 
       if ('_meiliSearchSources' === name) {
-        turn.sources = Array.isArray(parsed) ? parsed : parsed?.sources ?? []
+        // Confirmed shape on Meilisearch 1.52: an object wrapping the array, never a bare array.
+        turn.sources = parsed?.sources ?? []
       } else if ('_meiliSearchProgress' === name) {
-        turn.progress = parsed?.message ?? parsed?.status ?? null
+        turn.progress = parseProgress(parsed ?? {})
       }
       toolArguments.delete(index)
     }

--- a/app/composables/useChatCompletion.ts
+++ b/app/composables/useChatCompletion.ts
@@ -131,7 +131,11 @@ export const useChatCompletion = (workspace: string, accessKey?: MaybeRef<string
 
     self.error = null
     self.turns.push({ role: 'user', content: prompt.trim(), sources: [], progress: null })
-    const turn: ChatTurn = { role: 'assistant', content: '', sources: [], progress: null }
+    // A reactive object, because `self.turns` stores what it is handed as-is: mutating a plain
+    // one through this local reference would never notify Vue. The answer would then only show
+    // up when `streaming` flips at the very end — in one block, never streamed — and `progress`
+    // would never paint at all, being nulled again before anything else triggers a render.
+    const turn = reactive<ChatTurn>({ role: 'assistant', content: '', sources: [], progress: null })
     self.turns.push(turn)
 
     // History is sent verbatim, minus our own display-only fields.

--- a/app/composables/useChatWorkspaces.ts
+++ b/app/composables/useChatWorkspaces.ts
@@ -1,0 +1,97 @@
+import { useMeiliClient } from './useMeiliClient'
+
+/**
+ * Chat workspaces (conversational search). Most routes are covered by the official client
+ * (`meili.chat(uid)`), but two things are not, so those go through `meili.httpRequest`:
+ *
+ * - deleting a workspace: `DELETE /chats/{uid}` has no client method;
+ * - chat completions: `streamCompletion()` accepts neither an `AbortSignal` nor the `tools`
+ *   field, and without declaring the tools Meilisearch never streams back its sources.
+ *
+ * @see https://www.meilisearch.com/docs/reference/api/chats
+ */
+
+export const CHAT_SOURCES = ['openAi', 'azureOpenAi', 'mistral', 'gemini', 'vLlm'] as const
+export type ChatSource = (typeof CHAT_SOURCES)[number]
+
+/**
+ * Meilisearch 1.15+ accepts more prompt overrides than `ChatWorkspaceSettings` declares in
+ * meilisearch@0.59.0, so the shape is spelled out here rather than imported.
+ * On PATCH, an omitted field is left untouched while an explicit `null` resets it.
+ */
+export type ChatWorkspacePrompts = {
+  system?: string | null
+  searchDescription?: string | null
+  searchQParam?: string | null
+  searchFilterParam?: string | null
+  searchIndexUidParam?: string | null
+}
+
+export type ChatWorkspaceSettings = {
+  source: ChatSource
+  orgId?: string | null
+  projectId?: string | null
+  apiVersion?: string | null
+  deploymentId?: string | null
+  baseUrl?: string | null
+  /** Always redacted by Meilisearch when read back — never display or log it. */
+  apiKey?: string | null
+  prompts?: ChatWorkspacePrompts | null
+}
+
+export type ChatMessage = {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+export type ChatCompletionBody = {
+  model: string
+  messages: ChatMessage[]
+  stream: true
+  tools?: Array<{ type: 'function'; function: { name: string; description?: string } }>
+}
+
+/**
+ * Tools Meilisearch injects into the completion when the client declares them: one reports
+ * search progress, the other streams back the documents used to ground the answer.
+ */
+export const CHAT_TOOLS: NonNullable<ChatCompletionBody['tools']> = [
+  {
+    type: 'function',
+    function: {
+      name: '_meiliSearchProgress',
+      description: 'Reports real-time search progress to the user',
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: '_meiliSearchSources',
+      description: 'Provides sources and references for the information',
+    },
+  },
+]
+
+export const useChatWorkspaces = () => {
+  const meili = useMeiliClient()
+
+  const list = () => meili.getChatWorkspaces()
+
+  const getSettings = (uid: string) => meili.chat(uid).get() as Promise<ChatWorkspaceSettings>
+
+  const updateSettings = (uid: string, settings: Partial<ChatWorkspaceSettings>) =>
+    meili.httpRequest.patch<ChatWorkspaceSettings>({ path: `chats/${uid}/settings`, body: settings })
+
+  const resetSettings = (uid: string) => meili.chat(uid).reset()
+
+  const remove = (uid: string) => meili.httpRequest.delete({ path: `chats/${uid}` })
+
+  const streamCompletion = (uid: string, body: ChatCompletionBody, signal?: AbortSignal) =>
+    meili.httpRequest.postStream({
+      path: `chats/${uid}/chat/completions`,
+      body,
+      extraRequestInit: { signal },
+    })
+
+  return { list, getSettings, updateSettings, resetSettings, remove, streamCompletion }
+}

--- a/app/composables/useChatWorkspaces.ts
+++ b/app/composables/useChatWorkspaces.ts
@@ -1,3 +1,4 @@
+import { useCredentials } from '~/stores'
 import { useMeiliClient } from './useMeiliClient'
 
 /**
@@ -72,8 +73,19 @@ export const CHAT_TOOLS: NonNullable<ChatCompletionBody['tools']> = [
   },
 ]
 
+/**
+ * `POST /chats/{uid}/chat/completions` unwraps the request's bearer token unconditionally
+ * (`extract_token_from_request(&req)?.unwrap()`), so an instance started without a master key
+ * panics and drops the connection — the browser only sees a failed request — whenever no
+ * `Authorization` header is sent. Such an instance accepts any token, hence this placeholder.
+ *
+ * @see https://github.com/meilisearch/meilisearch/blob/v1.53.1/crates/meilisearch/src/routes/chats/chat_completions.rs#L654
+ */
+const UNAUTHENTICATED_INSTANCE_TOKEN = 'meiliweb'
+
 export const useChatWorkspaces = () => {
   const meili = useMeiliClient()
+  const { credentials } = toRefs(useCredentials())
 
   const list = () => meili.getChatWorkspaces()
 
@@ -90,7 +102,12 @@ export const useChatWorkspaces = () => {
     meili.httpRequest.postStream({
       path: `chats/${uid}/chat/completions`,
       body,
-      extraRequestInit: { signal },
+      extraRequestInit: {
+        signal,
+        headers: credentials.value?.accessKey
+          ? undefined
+          : { Authorization: `Bearer ${UNAUTHENTICATED_INSTANCE_TOKEN}` },
+      },
     })
 
   return { list, getSettings, updateSettings, resetSettings, remove, streamCompletion }

--- a/app/composables/useChatWorkspaces.ts
+++ b/app/composables/useChatWorkspaces.ts
@@ -1,3 +1,4 @@
+import type { MaybeRef } from 'vue'
 import { useCredentials } from '~/stores'
 import { useMeiliClient } from './useMeiliClient'
 
@@ -83,9 +84,19 @@ export const CHAT_TOOLS: NonNullable<ChatCompletionBody['tools']> = [
  */
 const UNAUTHENTICATED_INSTANCE_TOKEN = 'meiliweb'
 
-export const useChatWorkspaces = () => {
+/**
+ * @param completionKey Access key the completions run under. Meilisearch derives the LLM's
+ *   reach from the request's bearer token — a scoped key or a tenant token narrows which
+ *   indexes and documents it gets to search. Empty falls back to the connection key.
+ */
+export const useChatWorkspaces = (completionKey?: MaybeRef<string>) => {
   const meili = useMeiliClient()
   const { credentials } = toRefs(useCredentials())
+
+  // Read at call time, not at setup time, so switching key takes effect on the next question.
+  const completionHeaders = () => ({
+    Authorization: `Bearer ${unref(completionKey)?.trim() || credentials.value?.accessKey || UNAUTHENTICATED_INSTANCE_TOKEN}`,
+  })
 
   const list = () => meili.getChatWorkspaces()
 
@@ -102,12 +113,7 @@ export const useChatWorkspaces = () => {
     meili.httpRequest.postStream({
       path: `chats/${uid}/chat/completions`,
       body,
-      extraRequestInit: {
-        signal,
-        headers: credentials.value?.accessKey
-          ? undefined
-          : { Authorization: `Bearer ${UNAUTHENTICATED_INSTANCE_TOKEN}` },
-      },
+      extraRequestInit: { signal, headers: completionHeaders() },
     })
 
   return { list, getSettings, updateSettings, resetSettings, remove, streamCompletion }

--- a/app/pages/chat/[workspace]/index.vue
+++ b/app/pages/chat/[workspace]/index.vue
@@ -33,7 +33,7 @@
             <p class="whitespace-pre-wrap">{{ turn.content }}</p>
             <p v-if="turn.progress" class="flex items-center gap-2 text-xs text-gray-500 italic">
               <span class="size-2 animate-pulse rounded-full bg-primary-600" />
-              {{ turn.progress }}
+              {{ progressLabel(turn.progress) }}
             </p>
             <span v-else-if="'assistant' === turn.role && streaming && !turn.content" class="text-xs text-gray-500">
               {{ t('thinking') }}
@@ -76,7 +76,7 @@ import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
 import Alert from '~/components/layout/Alert.vue'
 import DocumentationLink from '~/components/layout/DocumentationLink.vue'
 import Button from '~/components/layout/forms/Button.vue'
-import { useChatCompletion } from '~/composables'
+import { useChatCompletion, type ChatProgress } from '~/composables'
 import { useCredentials, useChatAvailability, type CredentialsRecord } from '~/stores'
 import { safeToRefs } from '~/utils'
 
@@ -106,6 +106,19 @@ const submit = async () => {
   await send(value, model.value || DEFAULT_MODEL)
 }
 
+const progressLabel = ({ indexUid: index, query, filter }: ChatProgress) => {
+  if (query && filter) {
+    return t('progress.queryAndFilter', { index, query, filter })
+  }
+  if (query) {
+    return t('progress.query', { index, query })
+  }
+  if (filter) {
+    return t('progress.filter', { index, filter })
+  }
+  return t('progress.index', { index })
+}
+
 await until(loading).toBe(false)
 </script>
 
@@ -115,6 +128,11 @@ en:
   subtitle: Ask questions about your indexes.
   empty: Ask anything about the indexes this workspace can search.
   thinking: Thinking...
+  progress:
+    index: 'Searching {index}...'
+    query: 'Searching {index} for "{query}"...'
+    filter: 'Searching {index} with filter {filter}...'
+    queryAndFilter: 'Searching {index} for "{query}" with filter {filter}...'
   labels:
     model: Model
   placeholders:

--- a/app/pages/chat/[workspace]/index.vue
+++ b/app/pages/chat/[workspace]/index.vue
@@ -27,54 +27,43 @@
         <p class="text-lg font-light">{{ t('empty') }}</p>
       </div>
 
-      <ul v-else class="grow space-y-4 overflow-y-auto">
-        <li v-for="(turn, index) of turns" :key="index" class="flex flex-col gap-2">
-          <div :class="['user' === turn.role ? 'self-end bg-primary-600 text-white' : 'bg-gray-100', BUBBLE_CLASSES]">
-            <p class="whitespace-pre-wrap">{{ turn.content }}</p>
-            <p v-if="turn.progress" class="flex items-center gap-2 text-xs text-gray-500 italic">
-              <span class="size-2 animate-pulse rounded-full bg-primary-600" />
-              {{ progressLabel(turn.progress) }}
-            </p>
-            <span v-else-if="'assistant' === turn.role && streaming && !turn.content" class="text-xs text-gray-500">
-              {{ t('thinking') }}
-            </span>
-          </div>
-          <ChatSources v-if="turn.sources.length" :documents="turn.sources" class="max-w-2xl" />
-        </li>
-      </ul>
+      <UChatMessages
+        v-else
+        :messages="messages"
+        :status="status"
+        should-auto-scroll
+        class="min-h-0 grow"
+        :assistant="{ side: 'left', variant: 'soft' }"
+        :user="{ side: 'right', variant: 'solid', color: 'primary' }">
+        <template #content="{ message }">
+          <p class="whitespace-pre-wrap">{{ contentOf(message) }}</p>
+          <p v-if="progressOf(message)" class="flex items-center gap-2 text-xs text-gray-500 italic">
+            <span class="size-2 animate-pulse rounded-full bg-primary-600" />
+            {{ progressLabel(progressOf(message)!) }}
+          </p>
+          <span v-else-if="isThinking(message)" class="text-xs text-gray-500">{{ t('thinking') }}</span>
+          <ChatSources v-if="sourcesOf(message).length" :documents="sourcesOf(message)" class="mt-2 max-w-2xl" />
+        </template>
+      </UChatMessages>
 
-      <form class="flex flex-col gap-2 border-t border-gray-200 pt-4" @submit.prevent="submit()">
-        <div class="flex items-end gap-2">
-          <textarea
-            v-model="prompt"
-            v-focus
-            rows="2"
-            :placeholder="t('placeholders.prompt')"
-            class="form-input grow resize-none text-sm"
-            @keydown.enter.exact.prevent="submit()" />
-          <Button v-if="streaming" type="button" theme="danger" icon="mdi:stop" @click="stop()">
-            {{ t('actions.stop') }}
-          </Button>
-          <Button v-else type="submit" theme="primary" icon="heroicons:paper-airplane" :disabled="!prompt.trim()">
-            {{ t('actions.send') }}
-          </Button>
-        </div>
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
-          <label class="flex items-center gap-2 text-xs text-gray-500">
-            {{ t('labels.model') }}
-            <input v-model="model" class="form-input w-56 text-xs" :placeholder="DEFAULT_MODEL" />
-          </label>
-          <label v-tippy="t('hints.accessKey')" class="flex items-center gap-2 text-xs text-gray-500">
-            {{ t('labels.accessKey') }}
-            <input
-              v-model="accessKey"
-              type="password"
-              autocomplete="off"
-              class="form-input w-56 text-xs"
-              :placeholder="t('placeholders.accessKey')" />
-          </label>
-        </div>
-      </form>
+      <UChatPrompt v-model="prompt" v-focus :status :maxrows="4" @submit="submit()">
+        <UChatPromptSubmit @stop="stop()" />
+      </UChatPrompt>
+
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+        <UFormField :label="t('labels.model')">
+          <UInput v-model="model" size="xs" class="w-56" :placeholder="DEFAULT_MODEL" />
+        </UFormField>
+        <UFormField v-tippy="t('hints.accessKey')" :label="t('labels.accessKey')">
+          <UInput
+            v-model="accessKey"
+            type="password"
+            autocomplete="off"
+            size="xs"
+            class="w-56"
+            :placeholder="t('placeholders.accessKey')" />
+        </UFormField>
+      </div>
     </div>
   </Layout>
 </template>
@@ -87,11 +76,9 @@ import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
 import Alert from '~/components/layout/Alert.vue'
 import DocumentationLink from '~/components/layout/DocumentationLink.vue'
 import Button from '~/components/layout/forms/Button.vue'
-import { useChatCompletion, type ChatProgress } from '~/composables'
+import { useChatCompletion, type ChatProgress, type ChatTurn } from '~/composables'
 import { useCredentials, useChatAvailability, type CredentialsRecord } from '~/stores'
 import { safeToRefs } from '~/utils'
-
-const BUBBLE_CLASSES = 'flex max-w-2xl flex-col gap-2 rounded-lg px-4 py-3 text-sm'
 
 /** Meilisearch forwards `model` to the provider as-is, so it has to come from the user. */
 const DEFAULT_MODEL = 'gpt-4o-mini'
@@ -114,6 +101,24 @@ const accessKey = useLocalStorage(`${preference}-access-key`, '')
 
 const { turns, streaming, error, send, stop, clear } = useChatCompletion(workspace, accessKey)
 const prompt = ref('')
+
+// `UChatMessages`/`UChatPrompt` speak the AI SDK message shape; the index doubles as the id
+// since turns are never reordered, only appended to or replaced wholesale by `clear()`.
+const messages = computed(() =>
+  turns.value.map((turn, index) => ({
+    id: String(index),
+    role: turn.role,
+    parts: [{ type: 'text' as const, text: turn.content }],
+  })),
+)
+const status = computed(() => (streaming.value ? 'streaming' : 'ready'))
+
+const turnOf = (message: { id: string }): ChatTurn => turns.value[Number(message.id)]
+const contentOf = (message: { id: string }) => turnOf(message).content
+const sourcesOf = (message: { id: string }) => turnOf(message).sources
+const progressOf = (message: { id: string }) => turnOf(message).progress
+const isThinking = (message: { id: string }) =>
+  streaming.value && 'assistant' === message.role && !turnOf(message).content && !turnOf(message).progress
 
 const submit = async () => {
   const value = prompt.value
@@ -154,7 +159,6 @@ en:
   hints:
     accessKey: Meilisearch key the conversation runs under. A scoped key or a tenant token restricts the indexes and documents the LLM can search.
   placeholders:
-    prompt: Ask a question... (Enter to send, Shift+Enter for a new line)
     accessKey: Defaults to your instance key
   actions:
     backToList: Back to workspaces

--- a/app/pages/chat/[workspace]/index.vue
+++ b/app/pages/chat/[workspace]/index.vue
@@ -59,10 +59,21 @@
             {{ t('actions.send') }}
           </Button>
         </div>
-        <label class="flex items-center gap-2 text-xs text-gray-500">
-          {{ t('labels.model') }}
-          <input v-model="model" class="form-input w-56 text-xs" :placeholder="DEFAULT_MODEL" />
-        </label>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+          <label class="flex items-center gap-2 text-xs text-gray-500">
+            {{ t('labels.model') }}
+            <input v-model="model" class="form-input w-56 text-xs" :placeholder="DEFAULT_MODEL" />
+          </label>
+          <label v-tippy="t('hints.accessKey')" class="flex items-center gap-2 text-xs text-gray-500">
+            {{ t('labels.accessKey') }}
+            <input
+              v-model="accessKey"
+              type="password"
+              autocomplete="off"
+              class="form-input w-56 text-xs"
+              :placeholder="t('placeholders.accessKey')" />
+          </label>
+        </div>
       </form>
     </div>
   </Layout>
@@ -93,11 +104,15 @@ const workspace = route.params.workspace as string
 useHead({ title: `${workspace} - ${t('title')}` })
 
 const { available, loading } = safeToRefs(useChatAvailability())
-const { turns, streaming, error, send, stop, clear } = useChatCompletion(workspace)
 
-// The model is a per-instance, per-workspace preference, not a workspace setting.
+// The model and the access key are per-instance, per-workspace preferences, not workspace
+// settings: Meilisearch stores neither, so they live in localStorage next to the credentials.
 const { credentials } = useCredentials()
-const model = useLocalStorage(`${(credentials as CredentialsRecord).baseUri}-chat-${workspace}-model`, DEFAULT_MODEL)
+const preference = `${(credentials as CredentialsRecord).baseUri}-chat-${workspace}`
+const model = useLocalStorage(`${preference}-model`, DEFAULT_MODEL)
+const accessKey = useLocalStorage(`${preference}-access-key`, '')
+
+const { turns, streaming, error, send, stop, clear } = useChatCompletion(workspace, accessKey)
 const prompt = ref('')
 
 const submit = async () => {
@@ -135,8 +150,12 @@ en:
     queryAndFilter: 'Searching {index} for "{query}" with filter {filter}...'
   labels:
     model: Model
+    accessKey: API key
+  hints:
+    accessKey: Meilisearch key the conversation runs under. A scoped key or a tenant token restricts the indexes and documents the LLM can search.
   placeholders:
     prompt: Ask a question... (Enter to send, Shift+Enter for a new line)
+    accessKey: Defaults to your instance key
   actions:
     backToList: Back to workspaces
     settings: Settings

--- a/app/pages/chat/[workspace]/index.vue
+++ b/app/pages/chat/[workspace]/index.vue
@@ -32,7 +32,7 @@
         :messages="messages"
         :status="status"
         should-auto-scroll
-        class="min-h-0 grow"
+        :spacing-offset="160"
         :assistant="{ side: 'left', variant: 'soft' }"
         :user="{ side: 'right', variant: 'solid', color: 'primary' }">
         <template #content="{ message }">
@@ -46,23 +46,27 @@
         </template>
       </UChatMessages>
 
-      <UChatPrompt v-model="prompt" v-focus :status :maxrows="4" @submit="submit()">
-        <UChatPromptSubmit @stop="stop()" />
-      </UChatPrompt>
+      <!-- Sticky to the page's own scroll container (see Layout.vue), so the translucent
+      prompt floats over the tail of the conversation instead of fighting it for height. -->
+      <div class="sticky bottom-0 z-10 flex flex-col gap-2 bg-white/75 pt-2 backdrop-blur">
+        <UChatPrompt v-model="prompt" v-focus :status :maxrows="4" @submit="submit()">
+          <UChatPromptSubmit @stop="stop()" />
+        </UChatPrompt>
 
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
-        <UFormField :label="t('labels.model')">
-          <UInput v-model="model" size="xs" class="w-56" :placeholder="DEFAULT_MODEL" />
-        </UFormField>
-        <UFormField v-tippy="t('hints.accessKey')" :label="t('labels.accessKey')">
-          <UInput
-            v-model="accessKey"
-            type="password"
-            autocomplete="off"
-            size="xs"
-            class="w-56"
-            :placeholder="t('placeholders.accessKey')" />
-        </UFormField>
+        <div class="flex flex-col gap-2 pb-2 sm:flex-row sm:items-center sm:gap-6">
+          <UFormField :label="t('labels.model')">
+            <UInput v-model="model" size="xs" class="w-56" :placeholder="DEFAULT_MODEL" />
+          </UFormField>
+          <UFormField v-tippy="t('hints.accessKey')" :label="t('labels.accessKey')">
+            <UInput
+              v-model="accessKey"
+              type="password"
+              autocomplete="off"
+              size="xs"
+              class="w-56"
+              :placeholder="t('placeholders.accessKey')" />
+          </UFormField>
+        </div>
       </div>
     </div>
   </Layout>

--- a/app/pages/chat/[workspace]/index.vue
+++ b/app/pages/chat/[workspace]/index.vue
@@ -1,0 +1,128 @@
+<template>
+  <Layout :title="workspace" :subtitle="t('subtitle')">
+    <template #title-actions>
+      <NuxtLink v-tippy="t('actions.backToList')" to="/chat">
+        <Icon name="gg:list" />
+      </NuxtLink>
+      <DocumentationLink href="https://www.meilisearch.com/docs/capabilities/conversational_search/overview" />
+    </template>
+    <template #actions>
+      <Button :as="NuxtLink" :to="`/chat/${workspace}/settings`" icon="heroicons:cog-6-tooth">
+        {{ t('actions.settings') }}
+      </Button>
+      <Button v-if="turns.length" icon="heroicons:trash" :disabled="streaming" @click="clear()">
+        {{ t('actions.clear') }}
+      </Button>
+    </template>
+
+    <ChatUnavailableAlert v-if="!available" />
+
+    <div v-else class="flex h-full flex-col gap-4">
+      <Alert v-if="error" dismissable theme="danger" @close="error = null">
+        {{ error }}
+      </Alert>
+
+      <div v-if="!turns.length" class="flex grow flex-col items-center justify-center gap-4 text-gray-500">
+        <p class="text-5xl font-light">💬</p>
+        <p class="text-lg font-light">{{ t('empty') }}</p>
+      </div>
+
+      <ul v-else class="grow space-y-4 overflow-y-auto">
+        <li v-for="(turn, index) of turns" :key="index" class="flex flex-col gap-2">
+          <div :class="['user' === turn.role ? 'self-end bg-primary-600 text-white' : 'bg-gray-100', BUBBLE_CLASSES]">
+            <p class="whitespace-pre-wrap">{{ turn.content }}</p>
+            <p v-if="turn.progress" class="flex items-center gap-2 text-xs text-gray-500 italic">
+              <span class="size-2 animate-pulse rounded-full bg-primary-600" />
+              {{ turn.progress }}
+            </p>
+            <span v-else-if="'assistant' === turn.role && streaming && !turn.content" class="text-xs text-gray-500">
+              {{ t('thinking') }}
+            </span>
+          </div>
+          <ChatSources v-if="turn.sources.length" :documents="turn.sources" class="max-w-2xl" />
+        </li>
+      </ul>
+
+      <form class="flex flex-col gap-2 border-t border-gray-200 pt-4" @submit.prevent="submit()">
+        <div class="flex items-end gap-2">
+          <textarea
+            v-model="prompt"
+            v-focus
+            rows="2"
+            :placeholder="t('placeholders.prompt')"
+            class="form-input grow resize-none text-sm"
+            @keydown.enter.exact.prevent="submit()" />
+          <Button v-if="streaming" type="button" theme="danger" icon="mdi:stop" @click="stop()">
+            {{ t('actions.stop') }}
+          </Button>
+          <Button v-else type="submit" theme="primary" icon="heroicons:paper-airplane" :disabled="!prompt.trim()">
+            {{ t('actions.send') }}
+          </Button>
+        </div>
+        <label class="flex items-center gap-2 text-xs text-gray-500">
+          {{ t('labels.model') }}
+          <input v-model="model" class="form-input w-56 text-xs" :placeholder="DEFAULT_MODEL" />
+        </label>
+      </form>
+    </div>
+  </Layout>
+</template>
+
+<script setup lang="ts">
+import { NuxtLink } from '#components'
+import { until, useLocalStorage } from '@vueuse/core'
+import ChatSources from '~/components/chat/ChatSources.vue'
+import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
+import Alert from '~/components/layout/Alert.vue'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import { useChatCompletion } from '~/composables'
+import { useCredentials, useChatAvailability, type CredentialsRecord } from '~/stores'
+import { safeToRefs } from '~/utils'
+
+const BUBBLE_CLASSES = 'flex max-w-2xl flex-col gap-2 rounded-lg px-4 py-3 text-sm'
+
+/** Meilisearch forwards `model` to the provider as-is, so it has to come from the user. */
+const DEFAULT_MODEL = 'gpt-4o-mini'
+
+const { t } = useI18n()
+const route = useRoute()
+const workspace = route.params.workspace as string
+
+// Register lifecycle-bound composables before the first `await` so they keep their component context.
+useHead({ title: `${workspace} - ${t('title')}` })
+
+const { available, loading } = safeToRefs(useChatAvailability())
+const { turns, streaming, error, send, stop, clear } = useChatCompletion(workspace)
+
+// The model is a per-instance, per-workspace preference, not a workspace setting.
+const { credentials } = useCredentials()
+const model = useLocalStorage(`${(credentials as CredentialsRecord).baseUri}-chat-${workspace}-model`, DEFAULT_MODEL)
+const prompt = ref('')
+
+const submit = async () => {
+  const value = prompt.value
+  prompt.value = ''
+  await send(value, model.value || DEFAULT_MODEL)
+}
+
+await until(loading).toBe(false)
+</script>
+
+<i18n>
+en:
+  title: Chat
+  subtitle: Ask questions about your indexes.
+  empty: Ask anything about the indexes this workspace can search.
+  thinking: Thinking...
+  labels:
+    model: Model
+  placeholders:
+    prompt: Ask a question... (Enter to send, Shift+Enter for a new line)
+  actions:
+    backToList: Back to workspaces
+    settings: Settings
+    send: Send
+    stop: Stop
+    clear: Clear
+</i18n>

--- a/app/pages/chat/[workspace]/settings.vue
+++ b/app/pages/chat/[workspace]/settings.vue
@@ -1,0 +1,68 @@
+<template>
+  <Layout :title="workspace" :subtitle="t('subtitle')">
+    <template #title-actions>
+      <NuxtLink v-tippy="t('actions.backToList')" to="/chat">
+        <Icon name="gg:list" />
+      </NuxtLink>
+      <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/chats" />
+    </template>
+    <template #actions>
+      <Button v-if="available" :as="NuxtLink" :to="`/chat/${workspace}`" icon="heroicons:chat-bubble-left-right">
+        {{ t('actions.openChat') }}
+      </Button>
+    </template>
+
+    <ChatUnavailableAlert v-if="!available" />
+
+    <ChatWorkspaceSettingsForm v-else :uid="workspace" :settings="settings" @saved="settings = $event" />
+  </Layout>
+</template>
+
+<script setup lang="ts">
+import { NuxtLink } from '#components'
+import { until } from '@vueuse/core'
+import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
+import ChatWorkspaceSettingsForm from '~/components/chat/ChatWorkspaceSettingsForm.vue'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import { useChatWorkspaces, type ChatWorkspaceSettings } from '~/composables'
+import { useChatAvailability } from '~/stores'
+import { safeToRefs, tryOrThrow } from '~/utils'
+
+const { t } = useI18n()
+const route = useRoute()
+const workspace = route.params.workspace as string
+
+// Register lifecycle-bound composables before the first `await` so they keep their component context.
+useHead({ title: `${workspace} - ${t('title')}` })
+
+const { getSettings } = useChatWorkspaces()
+const { available, loading } = safeToRefs(useChatAvailability())
+
+// Both gates resolve asynchronously; wait before calling /chats, which answers 404 on an
+// instance where the feature is off.
+await until(loading).toBe(false)
+
+// A workspace that has never been configured has no settings yet — Meilisearch answers 404
+// rather than defaults, which is a normal state right after creation, not an error.
+const settings = ref<ChatWorkspaceSettings>(
+  available.value
+    ? await tryOrThrow(async () => {
+        try {
+          return await getSettings(workspace)
+        } catch {
+          return { source: 'openAi' } as ChatWorkspaceSettings
+        }
+      })
+    : ({ source: 'openAi' } as ChatWorkspaceSettings),
+)
+</script>
+
+<i18n>
+en:
+  title: Chat settings
+  subtitle: LLM provider and prompts for this workspace.
+  actions:
+    backToList: Back to workspaces
+    openChat: Open chat
+</i18n>

--- a/app/pages/chat/index.vue
+++ b/app/pages/chat/index.vue
@@ -1,0 +1,135 @@
+<template>
+  <Layout :title="t('title')" :subtitle="t('subtitle')">
+    <template #title-actions>
+      <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/chats" />
+    </template>
+    <template #actions>
+      <Button v-if="available" theme="primary" icon="pajamas:doc-new" @click="createWorkspace()">
+        {{ t('actions.create') }}
+      </Button>
+    </template>
+
+    <ChatUnavailableAlert v-if="!available" />
+
+    <Alert v-else-if="!workspaces.length" :title="t('empty.title')">
+      {{ t('empty.text') }}
+    </Alert>
+
+    <Table v-else :items="workspaces" :columns="[t('columns.uid'), t('columns.actions')]">
+      <template #default="{ item }">
+        <td class="font-medium">{{ item.uid }}</td>
+        <td>
+          <div class="flex items-center gap-3">
+            <NuxtLink
+              v-tippy="t('actions.chat')"
+              :to="`/chat/${item.uid}`"
+              class="text-gray-500 hover:text-primary-600">
+              <Icon name="heroicons:chat-bubble-left-right" />
+            </NuxtLink>
+            <NuxtLink
+              v-tippy="t('actions.settings')"
+              :to="`/chat/${item.uid}/settings`"
+              class="text-gray-500 hover:text-primary-600">
+              <Icon name="heroicons:cog-6-tooth" />
+            </NuxtLink>
+            <button
+              type="button"
+              v-tippy="t('actions.delete')"
+              class="text-gray-500 hover:text-red-600"
+              @click="confirmDelete(item.uid)">
+              <Icon name="heroicons:trash" />
+            </button>
+          </div>
+        </td>
+      </template>
+    </Table>
+  </Layout>
+</template>
+
+<script setup lang="ts">
+import { until } from '@vueuse/core'
+import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
+import ChatWorkspaceNamePromptModal from '~/components/chat/ChatWorkspaceNamePromptModal.vue'
+import Alert from '~/components/layout/Alert.vue'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import Table from '~/components/layout/tables/Table.vue'
+import { useChatWorkspaces } from '~/composables'
+import {
+  DismissedDialog,
+  TOAST_FAILURE,
+  TOAST_PLEASEWAIT,
+  TOAST_SUCCESS,
+  useChatAvailability,
+  useConfirmationDialog,
+  usePromisifiedDialogs,
+  useToasts,
+} from '~/stores'
+import { safeToRefs, tryOrThrow } from '~/utils'
+
+const { t } = useI18n()
+// Register lifecycle-bound composables before the first `await` so they keep their component context.
+useHead({ title: t('title') })
+
+const { list, remove } = useChatWorkspaces()
+const { confirm } = useConfirmationDialog()
+const { openDialog } = usePromisifiedDialogs()
+const { createToast } = useToasts()
+const { available, loading } = safeToRefs(useChatAvailability())
+
+// Both gates resolve asynchronously; wait for them before deciding whether to call /chats,
+// which would answer 404 on an instance where the feature is off.
+await until(loading).toBe(false)
+
+const workspaces = ref<Array<{ uid: string }>>(available.value ? (await tryOrThrow(() => list())).results : [])
+
+const refresh = async () => {
+  workspaces.value = (await list()).results
+}
+
+const createWorkspace = async () => {
+  try {
+    const uid = await openDialog(ChatWorkspaceNamePromptModal)
+    await navigateTo(`/chat/${uid}/settings`)
+  } catch (e) {
+    if (!(e instanceof DismissedDialog)) {
+      throw e
+    }
+  }
+}
+
+const confirmDelete = async (uid: string) => {
+  if (!(await confirm({ text: t('confirmations.delete', { uid }) }))) {
+    return
+  }
+  const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: t('toasts.deleting') })
+  try {
+    await remove(uid)
+    toast.update({ ...TOAST_SUCCESS(t) })
+    await refresh()
+  } catch {
+    toast.update({ ...TOAST_FAILURE(t) })
+  }
+}
+</script>
+
+<i18n>
+en:
+  title: Chat
+  subtitle: Conversational search workspaces backed by an LLM provider.
+  columns:
+    uid: Workspace
+    actions: Actions
+  empty:
+    title: No chat workspace yet
+    text: Create one to configure an LLM provider and start chatting with your indexes.
+  actions:
+    create: Create
+    chat: Open chat
+    settings: Settings
+    delete: Delete
+  confirmations:
+    delete: 'Do you really want to delete the workspace "{uid}" and its settings?'
+  toasts:
+    deleting: Deleting workspace...
+</i18n>

--- a/app/pages/indexes/[indexUid]/settings.vue
+++ b/app/pages/indexes/[indexUid]/settings.vue
@@ -8,7 +8,7 @@
     <div class="grid grid-cols-12 gap-4">
       <menu class="col-span-3 mb-12 space-y-3">
         <li
-          v-for="{ href, text, current } of navigation"
+          v-for="{ href, text, current } of visibleNavigation"
           class="block w-full rounded-lg shadow-md"
           :class="current ? 'bg-primary-600 text-white' : 'bg-gray-50 hover:bg-gray-100'">
           <NuxtLink :to="href" class="block size-full px-2 py-2.5 text-sm">
@@ -27,19 +27,23 @@
 import { NuxtLink, NuxtPage } from '#components'
 import { onMounted } from 'vue'
 import { useMeiliClient } from '~/composables'
-import { tryOrThrow } from '~/utils'
+import { useChatAvailability } from '~/stores'
+import { safeToRefs, tryOrThrow } from '~/utils'
 import humanizeString from 'humanize-string'
 
 const { t } = useI18n()
 const route = useRoute()
 const indexUid = route.params.indexUid
 const meili = useMeiliClient()
+const { available: chatAvailable } = safeToRefs(useChatAvailability())
 const index = await tryOrThrow(() => meili.getIndex(indexUid as string))
 
 type NavigationItem = {
   href: string
   text: string
   current: boolean
+  /** Left out when the setting the entry edits is unavailable on this instance. */
+  visible?: boolean
 }
 
 const navigation: Array<NavigationItem> = reactive([
@@ -114,6 +118,12 @@ const navigation: Array<NavigationItem> = reactive([
     text: t('menu.embedders'),
   },
   {
+    href: `/indexes/${index.uid}/settings/chat`,
+    current: computed(() => 'indexes-indexUid-settings-chat' === route.name),
+    visible: computed(() => chatAvailable.value),
+    text: t('menu.chat'),
+  },
+  {
     href: `/indexes/${index.uid}/settings/foreign-keys`,
     current: computed(() => 'indexes-indexUid-settings-foreign-keys' === route.name),
     text: t('menu.foreignKeys'),
@@ -124,6 +134,8 @@ const navigation: Array<NavigationItem> = reactive([
     text: t('menu.localSettings'),
   },
 ])
+
+const visibleNavigation = computed(() => navigation.filter(({ visible }) => visible ?? true))
 
 onMounted(() => {
   if ('indexes-indexUid-settings' === route.name) {
@@ -152,6 +164,7 @@ en:
     separatorTokens: Separator Tokens
     nonSeparatorTokens: Non-Separator Tokens
     embedders: Embedders
+    chat: Chat
     foreignKeys: Foreign Keys
     localSettings: Local settings
   actions:

--- a/app/pages/indexes/[indexUid]/settings/chat.vue
+++ b/app/pages/indexes/[indexUid]/settings/chat.vue
@@ -17,29 +17,21 @@
         {{ error }}
       </Alert>
 
-      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
-        <Label :for="id">{{ t('labels.description') }}</Label>
-        <Textarea :id v-model="self.settings.description" class="w-full" :rows="3" />
-        <span class="text-sm font-light text-gray-500">{{ t('hints.description') }}</span>
-      </UniqueId>
+      <UFormField :label="t('labels.description')" :help="t('hints.description')">
+        <UTextarea v-model="self.settings.description" class="w-full" :rows="3" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
-        <Label :for="id">{{ t('labels.documentTemplate') }}</Label>
-        <Textarea :id v-model="self.settings.documentTemplate" class="w-full font-mono text-xs" :rows="6" />
-        <span class="text-sm font-light text-gray-500">{{ t('hints.documentTemplate') }}</span>
-      </UniqueId>
+      <UFormField :label="t('labels.documentTemplate')" :help="t('hints.documentTemplate')">
+        <UTextarea v-model="self.settings.documentTemplate" class="w-full font-mono text-xs" :rows="6" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
-        <Label :for="id">{{ t('labels.documentTemplateMaxBytes') }}</Label>
-        <input :id v-model="self.settings.documentTemplateMaxBytes" type="number" min="1" class="form-input w-40" />
-        <span class="text-sm font-light text-gray-500">{{ t('hints.documentTemplateMaxBytes') }}</span>
-      </UniqueId>
+      <UFormField :label="t('labels.documentTemplateMaxBytes')" :help="t('hints.documentTemplateMaxBytes')">
+        <UInput v-model="self.settings.documentTemplateMaxBytes" type="number" :min="1" class="w-40" />
+      </UFormField>
 
-      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
-        <Label :for="id">{{ t('labels.searchParameters') }}</Label>
-        <Textarea :id v-model="self.settings.searchParameters" class="w-full font-mono text-xs" :rows="8" />
-        <span class="text-sm font-light text-gray-500">{{ t('hints.searchParameters') }}</span>
-      </UniqueId>
+      <UFormField :label="t('labels.searchParameters')" :help="t('hints.searchParameters')">
+        <UTextarea v-model="self.settings.searchParameters" class="w-full font-mono text-xs" :rows="8" />
+      </UFormField>
 
       <footer class="flex justify-end">
         <Buttons>
@@ -55,13 +47,10 @@
 import { until } from '@vueuse/core'
 import type { ChatSettings } from 'meilisearch'
 import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
-import UniqueId from '~/components/UniqueId.vue'
 import Alert from '~/components/layout/Alert.vue'
 import DocumentationLink from '~/components/layout/DocumentationLink.vue'
 import Button from '~/components/layout/forms/Button.vue'
 import Buttons from '~/components/layout/forms/Buttons.vue'
-import Label from '~/components/layout/forms/Label.vue'
-import Textarea from '~/components/layout/forms/Textarea.vue'
 import { useFormSubmit, useTask } from '~/composables'
 import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, useChatAvailability, useToasts } from '~/stores'
 import { resettableRef, safeToRefs } from '~/utils'

--- a/app/pages/indexes/[indexUid]/settings/chat.vue
+++ b/app/pages/indexes/[indexUid]/settings/chat.vue
@@ -1,0 +1,149 @@
+<template>
+  <form class="space-y-4" @reset.prevent="reset()" @submit.prevent="submit()">
+    <h3 class="inline-flex w-full items-start justify-between">
+      <span class="inline-flex flex-col gap-1">
+        <span class="text-xl font-semibold">{{ t('title') }}</span>
+        <span class="text-sm text-gray-600 italic">
+          {{ t('description') }}
+        </span>
+      </span>
+      <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/settings/update-chat" />
+    </h3>
+
+    <ChatUnavailableAlert v-if="!available" />
+
+    <template v-else>
+      <Alert v-if="error" dismissable theme="danger" @close="error = null">
+        {{ error }}
+      </Alert>
+
+      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
+        <Label :for="id">{{ t('labels.description') }}</Label>
+        <Textarea :id v-model="self.settings.description" class="w-full" :rows="3" />
+        <span class="text-sm font-light text-gray-500">{{ t('hints.description') }}</span>
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
+        <Label :for="id">{{ t('labels.documentTemplate') }}</Label>
+        <Textarea :id v-model="self.settings.documentTemplate" class="w-full font-mono text-xs" :rows="6" />
+        <span class="text-sm font-light text-gray-500">{{ t('hints.documentTemplate') }}</span>
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
+        <Label :for="id">{{ t('labels.documentTemplateMaxBytes') }}</Label>
+        <input :id v-model="self.settings.documentTemplateMaxBytes" type="number" min="1" class="form-input w-40" />
+        <span class="text-sm font-light text-gray-500">{{ t('hints.documentTemplateMaxBytes') }}</span>
+      </UniqueId>
+
+      <UniqueId v-slot="{ id }" as="div" class="space-y-1 *:block">
+        <Label :for="id">{{ t('labels.searchParameters') }}</Label>
+        <Textarea :id v-model="self.settings.searchParameters" class="w-full font-mono text-xs" :rows="8" />
+        <span class="text-sm font-light text-gray-500">{{ t('hints.searchParameters') }}</span>
+      </UniqueId>
+
+      <footer class="flex justify-end">
+        <Buttons>
+          <Button type="reset" :disabled="!modified || loading" />
+          <Button type="submit" :disabled="!modified || loading" :loading="loading" />
+        </Buttons>
+      </footer>
+    </template>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { until } from '@vueuse/core'
+import type { ChatSettings } from 'meilisearch'
+import ChatUnavailableAlert from '~/components/chat/ChatUnavailableAlert.vue'
+import UniqueId from '~/components/UniqueId.vue'
+import Alert from '~/components/layout/Alert.vue'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import Textarea from '~/components/layout/forms/Textarea.vue'
+import { useFormSubmit, useTask } from '~/composables'
+import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, useChatAvailability, useToasts } from '~/stores'
+import { resettableRef, safeToRefs } from '~/utils'
+
+type Props = {
+  indexUid: string
+}
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const meili = useMeiliClient()
+const index = meili.index(props.indexUid)
+const { loading, error, handle } = useFormSubmit()
+const processTask = useTask()
+const { createToast } = useToasts()
+const { available, loading: checkingAvailability } = safeToRefs(useChatAvailability())
+
+useHead({ title: `${t('title')} - ${index.uid}` })
+
+/** `searchParameters` is free-form search options, edited as raw JSON rather than as a form. */
+const asForm = ({ description, documentTemplate, documentTemplateMaxBytes, searchParameters }: ChatSettings) => ({
+  description: description ?? '',
+  documentTemplate: documentTemplate ?? '',
+  documentTemplateMaxBytes: documentTemplateMaxBytes ?? 400,
+  searchParameters: JSON.stringify(searchParameters ?? {}, null, 2),
+})
+
+// The route only exists once the feature is on; both gates resolve asynchronously.
+await until(checkingAvailability).toBe(false)
+const {
+  value: settings,
+  reset,
+  modified,
+} = resettableRef(asForm(available.value ? await index.getChat() : ({} as ChatSettings)))
+const self = reactive({ settings })
+
+const payload = () => {
+  const { description, documentTemplate, documentTemplateMaxBytes, searchParameters } = self.settings
+  try {
+    return {
+      description,
+      documentTemplate,
+      documentTemplateMaxBytes: Number(documentTemplateMaxBytes),
+      searchParameters: JSON.parse(searchParameters || '{}'),
+    }
+  } catch {
+    throw new Error(t('errors.invalidSearchParameters'))
+  }
+}
+
+const submit = async () =>
+  handle(async () => {
+    // Inside `handle` so an unparseable JSON surfaces in the form's error alert.
+    const body = payload()
+    const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: t('toasts.saving') })
+    await processTask(() => index.updateChat(body), {
+      onSuccess: () => {
+        toast.update({ ...TOAST_SUCCESS(t) })
+        reset(toRaw(self.settings))
+      },
+      onCanceled: () => toast.update({ ...TOAST_FAILURE(t), text: t('toasts.texts.canceledTask') }),
+      onFailure: () => toast.update({ ...TOAST_FAILURE(t), text: t('toasts.texts.failedTask') }),
+    })
+  })
+</script>
+
+<i18n>
+en:
+  title: Chat
+  description: Extra context handed to the LLM so it knows when to search this index and what it gets back.
+  labels:
+    description: Index description
+    documentTemplate: Document template
+    documentTemplateMaxBytes: Document template max bytes
+    searchParameters: Search parameters
+  hints:
+    description: Tells the LLM what this index holds, so it can decide whether searching it is relevant.
+    documentTemplate: Liquid template rendering each matched document into the text the LLM reads.
+    documentTemplateMaxBytes: Rendered documents longer than this are truncated. Defaults to 400.
+    searchParameters: JSON search options applied to every search the LLM runs on this index, e.g. limit, sort or hybrid.
+  errors:
+    invalidSearchParameters: Search parameters must be a valid JSON object.
+  toasts:
+    saving: Updating chat settings...
+</i18n>

--- a/app/stores/chat-availability.ts
+++ b/app/stores/chat-availability.ts
@@ -1,0 +1,50 @@
+import { asyncComputed } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { useVersion } from './version'
+
+/** Conversational search (the `/chats` routes) landed in Meilisearch 1.15. */
+export const CHAT_MIN_VERSION = '>=1.15.0'
+
+/** Name of the experimental feature that unlocks the `/chats` routes. */
+export const CHAT_EXPERIMENTAL_FEATURE = 'chatCompletions'
+
+/**
+ * Whether chat workspaces can be used against the current instance. Both conditions must
+ * hold: a recent enough Meilisearch, and the `chatCompletions` experimental feature on.
+ *
+ * Kept as a store so the check is shared (top navigation + pages) instead of being fired
+ * once per component. Both inputs resolve asynchronously, hence `loading`: until it turns
+ * false, callers must not conclude that the feature is unavailable.
+ */
+export const useChatAvailability = defineStore('chat-availability', () => {
+  const { version, satisfiesVersion } = useVersion()
+
+  // `undefined` (rather than `false`) as the initial value is what makes `loading` able to
+  // tell "not fetched yet" from "fetched, and disabled".
+  const chatCompletionsEnabled = asyncComputed<boolean | undefined>(async () => {
+    // Instantiating the client inside the evaluator makes this re-run when the active
+    // instance changes, since `useMeiliClient()` reads the credentials store reactively.
+    const meili = useMeiliClient()
+    try {
+      // Direct call (not tryOrThrow): instances older than the endpoint answer 404, and a
+      // missing experimental-features route just means "unavailable", not "fatal error".
+      const features = (await meili.getExperimentalFeatures()) as Record<string, boolean>
+      return !!features[CHAT_EXPERIMENTAL_FEATURE]
+    } catch {
+      return false
+    }
+  }, undefined)
+
+  const self = reactive({
+    version,
+    chatCompletionsEnabled,
+    versionSupported: computed(() => satisfiesVersion(CHAT_MIN_VERSION)),
+  })
+
+  return {
+    available: computed(() => self.versionSupported && true === self.chatCompletionsEnabled),
+    loading: computed(() => !self.version || undefined === self.chatCompletionsEnabled),
+    versionSupported: computed(() => self.versionSupported),
+    chatCompletionsEnabled: computed(() => true === self.chatCompletionsEnabled),
+  }
+})

--- a/app/stores/index.ts
+++ b/app/stores/index.ts
@@ -1,3 +1,4 @@
+export * from './chat-availability'
 export * from './confirmation-dialog'
 export * from './credentials'
 export * from './promisified-dialogs'

--- a/app/stores/version.ts
+++ b/app/stores/version.ts
@@ -11,12 +11,17 @@ export const useVersion = defineStore('version', {
     },
   },
   actions: {
+    /**
+     * Prereleases are matched on purpose: dev and RC builds report versions like
+     * `1.52.0-rc.1`, which semver otherwise considers outside of every range — so a
+     * `>=1.52.0` gate would hide 1.52 features from someone actually running 1.52.
+     *
+     * `version` is an `asyncComputed` and stays `undefined` until the instance answers;
+     * `semver.satisfies(undefined, ...)` returns `false` on its own, so callers can gate
+     * without guarding. Features simply read as unavailable for one tick.
+     */
     satisfiesVersion(version: string) {
-      // `this.version` is an asyncComputed: it is undefined until the first fetch resolves,
-      // and semver.satisfies() throws on undefined. Treat "not known yet" as "not satisfied".
-      const pkgVersion = unref(this.version)?.pkgVersion
-      // Dev/RC builds report e.g. `1.52.0-rc.1`, which would not match `>=1.52.0` otherwise.
-      return !!pkgVersion && semver.satisfies(pkgVersion, version, { includePrerelease: true })
+      return semver.satisfies(unref(this.version)?.pkgVersion, version, { includePrerelease: true })
     },
   },
 })

--- a/app/stores/version.ts
+++ b/app/stores/version.ts
@@ -12,7 +12,11 @@ export const useVersion = defineStore('version', {
   },
   actions: {
     satisfiesVersion(version: string) {
-      return semver.satisfies(unref(this.version)?.pkgVersion, version)
+      // `this.version` is an asyncComputed: it is undefined until the first fetch resolves,
+      // and semver.satisfies() throws on undefined. Treat "not known yet" as "not satisfied".
+      const pkgVersion = unref(this.version)?.pkgVersion
+      // Dev/RC builds report e.g. `1.52.0-rc.1`, which would not match `>=1.52.0` otherwise.
+      return !!pkgVersion && semver.satisfies(pkgVersion, version, { includePrerelease: true })
     },
   },
 })


### PR DESCRIPTION
Implements Meilisearch chat workspaces (conversational search), gated on Meilisearch >= 1.15 **and** the `chatCompletions` experimental feature.

`main` has been merged in, so #76 and #77 are no longer part of this diff.

## Gating

`app/stores/chat-availability.ts` combines both conditions in one store, so the check is shared between the navigation and the pages instead of firing once per component. It exposes a `loading` flag — both inputs resolve asynchronously, and pages wait on it before calling `/chats`, which would answer 404 on an instance where the feature is off. When unavailable there is no top-menu entry, and the routes degrade to an explanatory alert.

## Workspaces

List, create and delete, backed by `meili.getChatWorkspaces()`. `DELETE /chats/{uid}` has no client method, so it goes through `meili.httpRequest`.

## Settings

LLM source (OpenAI, Azure OpenAI, Mistral, Gemini, vLLM), base URL, API key, the provider-specific fields (OpenAI org/project, Azure deployment/apiVersion) and the prompt overrides, plus reset-to-defaults.

🔒 **The API key is never prefilled.** Meilisearch redacts it when reading settings back, so echoing it would either send a masked value or overwrite the real secret. An empty field means "keep the current key". Fields that don't apply to the selected source are explicitly reset rather than left dangling, using PATCH semantics (omitted keeps, explicit `null` resets).

A workspace created a moment ago has no settings yet and Meilisearch answers 404 for it — a normal state, not an error, so the page falls back to defaults.

## Chat

Message list, prompt, send, stop. Answers stream in token by token from `POST /chats/{workspace}/chat/completions`, which speaks the OpenAI streaming protocol (SSE frames carrying `choices[0].delta`, terminated by `data: [DONE]`).

- **Sources.** Meilisearch only calls back its `_meiliSearchProgress` and `_meiliSearchSources` tools **when the request declares them**, so `CHAT_TOOLS` is always sent — without it the answer arrives ungrounded with no visible sources, which rather defeats the point. Progress shows while the search runs; the grounding documents are listed under each reply and link back to their index. Tool call `arguments` arrive in fragments and are concatenated per call before parsing.
- **Lifecycle.** The stream is aborted on stop, on unmount and on navigation away, so a half-read response never outlives the component. `streamCompletion()` from the client accepts neither an `AbortSignal` nor `tools`, so the request goes through `meili.httpRequest.postStream()`.
- **Model.** Meilisearch forwards `model` to the provider as-is, so it comes from the user and is remembered per instance and per workspace in localStorage.

## `app/stores/version.ts`

`satisfiesVersion` now passes `{ includePrerelease: true }` — dev and RC builds report versions like `1.15.0-rc.1`, which semver otherwise places outside every range. **This is the same change as #81**; whichever merges first, the other becomes a no-op.

## Needs a human 👀

`yarn format` + `yarn run check` clean, but **nothing here ran against a live instance** — that needs Meilisearch with `chatCompletions` on *and* a real LLM API key. Specifically unverified:

- the exact `_meiliSearchSources` argument shape (the code accepts both a bare array and `{ sources: [...] }`, because the docs don't pin it down);
- `_meiliSearchProgress` field names (`message` / `status`);
- that `gpt-4o-mini` is a sensible default model, and the whole model-passthrough assumption;
- rendering of long answers and of source documents with unusual shapes;
- the 404-on-fresh-workspace fallback.

Hand-rolled Tailwind was used for the message bubbles rather than `@nuxt/ui`'s chat primitives — worth revisiting if you'd rather standardise on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
