### PR TITLE
Fix: three shared UI defects surfaced by the test campaign (toast, Alert, Button i18n)

### DIFF
--- a/app/components/layout/Alert.vue
+++ b/app/components/layout/Alert.vue
@@ -2,7 +2,7 @@
   <UAlert
     :color="color"
     variant="subtle"
-    :title="title ?? t('errorTitle')"
+    :title="title ?? defaultTitle"
     :close="dismissable"
     :ui="{ title: 'text-lg font-semibold', description: 'text-sm' }"
     @update:open="emit('close')">
@@ -37,6 +37,11 @@ const color = computed(
       [match.default, 'neutral'],
     ]) as 'warning' | 'error' | 'success' | 'neutral',
 )
+
+// Only the `danger` theme has a sensible fallback title ("An error occured.").
+// Other themes render no title when none is given, rather than misleadingly
+// borrowing the error copy.
+const defaultTitle = computed(() => ('danger' === props.theme ? t('errorTitle') : undefined))
 </script>
 
 <i18n>

--- a/app/components/layout/forms/Button.vue
+++ b/app/components/layout/forms/Button.vue
@@ -72,4 +72,7 @@ const text = computed(() =>
 <i18n>
 en:
   loadingText: Please wait...
+  buttons:
+    submit: Submit
+    cancel: Cancel
 </i18n>

--- a/app/stores/toasts.ts
+++ b/app/stores/toasts.ts
@@ -46,18 +46,25 @@ export const useToasts = defineStore('toasts', () => {
   const nuxtToasts = useToast()
 
   // Adapt the historical toast options to Nuxt UI's toast props
-  const toToastProps = (options: CreateToastOptions) => ({
-    title: options.title,
-    description: options.text,
-    icon: options.icon,
-    duration: 0 === (options.ttl ?? TOAST_DEFAULT_TTL) ? Infinity : options.ttl ?? TOAST_DEFAULT_TTL,
-    close: options.dismissable ?? true,
-    ui: {
-      icon: ['size-6', ...(Array.isArray(options.iconClasses) ? options.iconClasses : [options.iconClasses ?? ''])]
-        .join(' ')
-        .trim(),
-    },
-  })
+  const toToastProps = (options: CreateToastOptions) => {
+    const indefinite = 0 === (options.ttl ?? TOAST_DEFAULT_TTL)
+    return {
+      title: options.title,
+      description: options.text,
+      icon: options.icon,
+      duration: indefinite ? Infinity : options.ttl ?? TOAST_DEFAULT_TTL,
+      // An indefinite toast has no "time remaining" to show. Nuxt UI's toast progress bar
+      // computes `remaining / duration`, which is `Infinity / Infinity` (NaN) once duration
+      // is Infinity — disable it here rather than let it feed NaN into reka-ui's ProgressRoot.
+      progress: !indefinite,
+      close: options.dismissable ?? true,
+      ui: {
+        icon: ['size-6', ...(Array.isArray(options.iconClasses) ? options.iconClasses : [options.iconClasses ?? ''])]
+          .join(' ')
+          .trim(),
+      },
+    }
+  }
 
   const createToast = (options: CreateToastOptions): Toast => {
     const id = ulid()


### PR DESCRIPTION
Three pre-existing, app-wide UI defects, found while end-to-end testing #78, #79, #80 and #81. None belongs to any of those PRs — each showed up on several of them, which is what identifies them as shared. Fixing them here once rather than four times.

## 1. Toast progress bar fed `NaN`, ~60 times a second

```
[Vue warn] Invalid prop: NaN/Infinity supplied to ProgressRoot
```

Traced through Nuxt UI's `Toast.vue` and reka-ui's `ToastRootImpl`: `TOAST_PLEASEWAIT` sets `ttl: 0`, which maps to `duration: Infinity`. `startTimer()` correctly bails out for `Infinity` — an indefinite toast is *supposed* to stay until the operation resolves — but the requestAnimationFrame loop driving the progress bar keeps running regardless and settles on `Infinity`, so `remaining / totalDuration` is `Infinity / Infinity` = `NaN`. That gets handed to reka-ui's `ProgressRoot`, which re-validates and logs on **every rAF tick for the toast's entire lifetime**.

So this was not an occasional warning, it was a continuous stream of them for as long as any "please wait" toast was on screen.

Fix: `toToastProps` now returns `progress: !indefinite`, so an indefinite toast never mounts the progress bar at all. Finite toasts are untouched, and the transition still works — `update()` merges into the current options and re-runs `toToastProps`, and both `TOAST_SUCCESS` and `TOAST_FAILURE` set `ttl: 5000`, so a toast that flips to success regains both a real duration and its progress bar.

### One symptom deliberately *not* changed

The #79 report also described a "please wait" toast that never transitioned to failure and never closed. The update path was traced end to end (`useToasts().update()` → `nuxtToasts.update()` → reactive `duration` change → `ToastRootImpl` watcher → `startTimer(5000)`) and **no mechanistic defect was found**. Two plausible explanations remain, neither warranting a speculative change to a shared component:

- the 60/sec `NaN` churn from the bug above was adding reactivity noise, which this fix removes anyway;
- reka-ui intentionally pauses the close timer while the pointer is over the toast viewport — if the tester's cursor was resting there, that is correct behaviour and looks identical to "never closes".

Flagged for browser verification rather than patched blind.

## 2. `Alert.vue` showed "An error occured." on non-error alerts

A `<Alert theme="warning">` with no explicit title rendered the **error** title. Found on #78, where the copy was a warning about a destructive action — so the component was announcing a failure that had not happened.

All 23 `<Alert` call sites were checked: every `theme="danger"` one omits `:title` and relies on the fallback, so that had to keep working; every `warning` / `success` one already passes an explicit title, so none depended on the buggy default.

Fix: the fallback title now applies only to `theme="danger"`. Other themes render no title unless given one — `UAlert` already guards the title with `v-if`, so `undefined` cleanly means "no title block".

## 3. Every `<Button type="submit"/>` logged an intlify warning

```
[intlify] Not found 'buttons.submit' key in 'en' locale messages, using the fallback to root
```

`buttons.submit` / `buttons.cancel` were declared only in `app.vue`'s global block, while `Button.vue` has its own i18n scope — so the lookup missed locally and resolved through `fallbackRoot` every time. The label rendered correctly, which is why this survived: pure console noise.

It is worth fixing because it fires on essentially every form in the app and buries real warnings. Two separate agents reviewing unrelated PRs each flagged it as a suspected bug and spent time ruling it out.

Fix: declare the fallback labels in `Button.vue`'s own `<i18n>` block. `app.vue` keeps its global keys — the settings editors still use them for `buttons.reset`.

## Needs a browser 👀

`yarn format` + `yarn run check` clean, but nothing was run: all worktrees in this batch share one `node_modules`, so no dev server. Worth confirming:

1. a "please wait" toast shows no console warning and no progress bar;
2. a failing long-running operation's toast flips to failure and auto-closes after ~5s (this is the open question from bug 1 — and check it without hovering the toast);
3. a `theme="warning"` alert with no title renders no title, and a `theme="danger"` one still says "An error occured.";
4. submitting any form produces no intlify warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
