### PR TITLE
Feat: debug toggle for search performance stats and ranking score details

### DIFF
--- a/app/components/documents/DebugSearchControl.vue
+++ b/app/components/documents/DebugSearchControl.vue
@@ -1,0 +1,45 @@
+<template>
+  <UPopover>
+    <button v-tippy="t('actions.toggle')" type="button">
+      <Icon
+        name="ph:bug-fill"
+        :class="[
+          'size-6',
+          enabled ? 'text-primary-600 hover:text-primary-800' : 'text-gray-600 hover:text-gray-800',
+        ]" />
+    </button>
+
+    <template #content>
+      <div class="w-72 space-y-4 p-4">
+        <USwitch v-model="showRankingScore" :label="t('labels.showRankingScore')" />
+        <USwitch v-model="showRankingScoreDetails" :label="t('labels.showRankingScoreDetails')" />
+        <USwitch
+          v-if="satisfiesVersion('>=1.35.0')"
+          v-model="showPerformanceDetails"
+          :label="t('labels.showPerformanceDetails')" />
+      </div>
+    </template>
+  </UPopover>
+</template>
+
+<script setup lang="ts">
+import { useVersion } from '~/stores'
+
+const showRankingScore = defineModel<boolean>('showRankingScore', { default: false })
+const showRankingScoreDetails = defineModel<boolean>('showRankingScoreDetails', { default: false })
+const showPerformanceDetails = defineModel<boolean>('showPerformanceDetails', { default: false })
+
+const { t } = useI18n()
+const { satisfiesVersion } = useVersion()
+const enabled = computed(() => showRankingScore.value || showRankingScoreDetails.value || showPerformanceDetails.value)
+</script>
+
+<i18n>
+en:
+  actions:
+    toggle: Debug options
+  labels:
+    showRankingScore: Show ranking score
+    showRankingScoreDetails: Show ranking score details
+    showPerformanceDetails: Show performance stats
+</i18n>

--- a/app/components/documents/DocumentCard.vue
+++ b/app/components/documents/DocumentCard.vue
@@ -62,7 +62,10 @@ const props = defineProps<Props>()
 
 const picture = computed(() => Object.values(props.document).find(looksLikeAPictureUrl) as string | null)
 
-const { fieldsWithoutPrimaryKey, nameField } = useFields(props.primaryKey, Object.keys(props.document))
+const { fieldsWithoutPrimaryKey, nameField } = useFields(
+  props.primaryKey,
+  computed(() => Object.keys(props.document)),
+)
 const self: any = reactive({
   nameField,
   name: computed(() => props.document[self.nameField]),

--- a/app/components/documents/DocumentsFooter.vue
+++ b/app/components/documents/DocumentsFooter.vue
@@ -9,6 +9,20 @@
       <dt>{{ t('labels.processingTime') }}:</dt>
       <dd>{{ processingTimeMs }}ms</dd>
     </dl>
+    <UPopover v-if="performanceDetails">
+      <button v-tippy="t('actions.showPerformanceDetails')" type="button">
+        <Icon name="mdi:speedometer" class="size-4 text-gray-600 hover:text-gray-800" />
+      </button>
+      <template #content>
+        <div class="max-w-sm p-4 text-xs">
+          <ObjectValueRenderer
+            :index-uid="indexUid"
+            field="performanceDetails"
+            :value="performanceDetails"
+            :level="0" />
+        </div>
+      </template>
+    </UPopover>
     <UniqueId as="div" v-slot="{ id }" class="inline-flex items-center gap-1">
       <select :id="id" v-model="itemsPerPage">
         <option :value="1">1</option>
@@ -45,6 +59,7 @@
 
 <script setup lang="ts">
 import { usePagination } from '~/composables'
+import ObjectValueRenderer from '~/components/documents/ObjectValueRenderer.vue'
 import type { Ref } from 'vue'
 
 type Props = {
@@ -54,6 +69,8 @@ type Props = {
   lastPage: number
   previousPage: number
   nextPage: number
+  indexUid?: string
+  performanceDetails?: Record<string, unknown>
 }
 
 defineProps<Props>()
@@ -65,6 +82,8 @@ const { getPageOffset } = usePagination(itemsPerPage)
 
 <i18n>
 en:
+  actions:
+    showPerformanceDetails: Show performance details
   labels:
     nbEstimatedHits: Nb. estimated hits
     processingTime: Processing time

--- a/app/composables/useIndexLocalSettings.ts
+++ b/app/composables/useIndexLocalSettings.ts
@@ -14,6 +14,9 @@ type UseIndexLocalSettings = {
   hybridEnabled: boolean
   hybridEmbedder: string | null
   hybridSemanticRatio: number
+  showRankingScore: boolean
+  showRankingScoreDetails: boolean
+  showPerformanceDetails: boolean
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -25,6 +28,9 @@ const DEFAULT_UPDATE_MODE = 'replace'
 const DEFAULT_HYBRID_ENABLED = false
 const DEFAULT_HYBRID_EMBEDDER = null
 const DEFAULT_HYBRID_SEMANTIC_RATIO = 0.5
+const DEFAULT_SHOW_RANKING_SCORE = false
+const DEFAULT_SHOW_RANKING_SCORE_DETAILS = false
+const DEFAULT_SHOW_PERFORMANCE_DETAILS = false
 
 export const useIndexLocalSettings = (indexUid: string) => {
   const { credentials } = useCredentials()
@@ -40,6 +46,9 @@ export const useIndexLocalSettings = (indexUid: string) => {
     hybridEnabled: DEFAULT_HYBRID_ENABLED,
     hybridEmbedder: DEFAULT_HYBRID_EMBEDDER,
     hybridSemanticRatio: DEFAULT_HYBRID_SEMANTIC_RATIO,
+    showRankingScore: DEFAULT_SHOW_RANKING_SCORE,
+    showRankingScoreDetails: DEFAULT_SHOW_RANKING_SCORE_DETAILS,
+    showPerformanceDetails: DEFAULT_SHOW_PERFORMANCE_DETAILS,
   })
 
   const self = reactive({ storage })
@@ -84,6 +93,18 @@ export const useIndexLocalSettings = (indexUid: string) => {
     hybridSemanticRatio: computed({
       get: () => self.storage.hybridSemanticRatio ?? DEFAULT_HYBRID_SEMANTIC_RATIO,
       set: (value: number) => (self.storage.hybridSemanticRatio = value),
+    }),
+    showRankingScore: computed({
+      get: () => self.storage.showRankingScore ?? DEFAULT_SHOW_RANKING_SCORE,
+      set: (value: boolean) => (self.storage.showRankingScore = value),
+    }),
+    showRankingScoreDetails: computed({
+      get: () => self.storage.showRankingScoreDetails ?? DEFAULT_SHOW_RANKING_SCORE_DETAILS,
+      set: (value: boolean) => (self.storage.showRankingScoreDetails = value),
+    }),
+    showPerformanceDetails: computed({
+      get: () => self.storage.showPerformanceDetails ?? DEFAULT_SHOW_PERFORMANCE_DETAILS,
+      set: (value: boolean) => (self.storage.showPerformanceDetails = value),
     }),
     // Call this whenever the stored embedder no longer matches the index's live embedder
     // list (renamed/deleted) — resets everything hybrid-related to its default in one go,

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -50,6 +50,11 @@
         v-model:semantic-ratio="hybridSemanticRatio"
         :embedders="embedderNames" />
 
+      <DebugSearchControl
+        v-model:show-ranking-score="showRankingScore"
+        v-model:show-ranking-score-details="showRankingScoreDetails"
+        v-model:show-performance-details="showPerformanceDetails" />
+
       <button v-tippy="t('actions.documentView')" @click="viewMode = 'documents'">
         <Icon
           name="fa-solid:id-card"
@@ -95,7 +100,7 @@
       :primary-key="primaryKey"
       :applied-filters="appliedFilters"
       :can-filter-geo-documents="canFilterGeoDocuments"
-      :fields="fields" />
+      :fields="displayFields" />
 
     <template #footer>
       <DocumentsFooter
@@ -106,7 +111,9 @@
         :previous-page="previousPage"
         :next-page="nextPage"
         :nb-total-items="resultset.estimatedTotalHits"
-        :processing-time-ms="resultset.processingTimeMs" />
+        :processing-time-ms="resultset.processingTimeMs"
+        :index-uid="index.uid"
+        :performance-details="resultset.performanceDetails" />
     </template>
   </Layout>
 </template>
@@ -124,13 +131,16 @@ import DocumentsAsTable from '~/components/documents/DocumentsAsTable.vue'
 import Button from '~/components/layout/forms/Button.vue'
 import DocumentsAsMap from '~/components/documents/DocumentsAsMap.vue'
 import HybridSearchControl from '~/components/documents/HybridSearchControl.vue'
+import DebugSearchControl from '~/components/documents/DebugSearchControl.vue'
 import { reactiveComputed } from '@vueuse/core'
+import { useVersion } from '~/stores'
 
 const { t } = useI18n()
 const route = useRoute()
 const indexUid = route.params.indexUid
 const meili = useMeiliClient()
 const tenant = useMultiTenancy()
+const { satisfiesVersion } = useVersion()
 const searchClient = reactiveComputed(() => (tenant.tenantToken ? useMeiliClient(tenant.tenantToken as string) : meili))
 const { formatDate } = useDateFormatter()
 const index = await tryOrThrow(() => meili.getIndex(indexUid as string))
@@ -154,6 +164,9 @@ const {
   hybridEmbedder,
   hybridSemanticRatio,
   resetHybridSearch,
+  showRankingScore,
+  showRankingScoreDetails,
+  showPerformanceDetails,
 } = useIndexLocalSettings(index.uid)
 const appliedFilters = reactive(new AppliedFilters()) as AppliedFilters
 const searchTerms = ref('')
@@ -196,9 +209,19 @@ const searchParams = reactive({
       ? { embedder: hybridEmbedder.value, semanticRatio: hybridSemanticRatio.value }
       : undefined,
   ),
+  showRankingScore,
+  showRankingScoreDetails,
+  // Guarded here too (not just hidden in DebugSearchControl's UI) so a value persisted while
+  // connected to a newer instance can't leak into a request against an older one.
+  showPerformanceDetails: computed(() => showPerformanceDetails.value && satisfiesVersion('>=1.35.0')),
 })
 const resultset = ref(await tryOrThrow(() => searchClient.index(index.uid).search(null, searchParams)))
 
+const displayFields = computed(() => [
+  ...fields.value,
+  ...(showRankingScore.value ? ['_rankingScore'] : []),
+  ...(showRankingScoreDetails.value ? ['_rankingScoreDetails'] : []),
+])
 const hasGeoDocuments = computed(() => Object.keys(stats.fieldDistribution).includes('_geo'))
 const canFilterGeoDocuments = computed(() => filterableAttributes.includes('_geo'))
 const self = reactive({


### PR DESCRIPTION
## Summary
- Adds a "Debug" popover next to the search bar on the documents page (mirrors the existing Hybrid Search popover pattern) with three switches: **show ranking score**, **show ranking score details**, and **show performance stats**.
- The performance-stats switch is version-gated to Meilisearch **≥ 1.35** (search performance observability, https://www.meilisearch.com/docs/changelog/changelog#search-performance-observability), hidden in the UI and guarded again when building the search request, via the existing `useVersion().satisfiesVersion(...)` pattern.
- Ranking score / ranking score details render as extra fields through the existing generic document field renderers (cards & table views) — no new display components needed.
- Performance details render in a popover next to the processing time in the footer, reusing `ObjectValueRenderer`.
- Fixes a pre-existing reactivity bug in `DocumentCard.vue`: `Object.keys(props.document)` was evaluated once at setup instead of reactively, so per-document field toggles never showed up on cards that reuse the same `v-for` key across searches (same document id).

## Test plan
- [x] Verified manually against a local Meilisearch 1.53.1 instance (movies dataset) via the browser preview: toggled all three switches on/off, confirmed `_rankingScore` / `_rankingScoreDetails` appear/disappear in both cards and table views, confirmed the performance-details popover shows the full breakdown from the API.
- [x] `yarn run check` (ESLint) — passes
- [x] `yarn lint` (Prettier) — passes
- [ ] Manual check against a Meilisearch instance < 1.35 to confirm the performance-stats switch is hidden (not tested — no such instance available locally; verified by code inspection against the existing, already-shipped version-gating pattern used elsewhere in the app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)