### PR TITLE
Feat: index compaction endpoint (Meilisearch >= 1.23)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -58,11 +58,16 @@ en:
       duplicateIndex: Copying {indexUid} to {newIndexUid}
       renameIndex: Renaming {indexUid} to {newIndexUid}
       swapIndexes: Swapping {indexUid} with {targetIndexUid}
+      compactIndex: Compacting {indexUid}
     texts:
       pleaseWait: Please wait...
       done: Done.
       canceledTask: Task was canceled.
       failedTask: Task failed.
+
+  confirmations:
+    compactIndex:
+      text: Compact this index? It may take a while depending on its size, and search/indexing operations on it will be slower during compaction.
 
   buttons:
     reset: Reset

--- a/app/composables/useIndexOperations.ts
+++ b/app/composables/useIndexOperations.ts
@@ -1,8 +1,16 @@
+import type { EnqueuedTask } from 'meilisearch'
 import IndexNamePromptModal from '~/components/settings/IndexNamePromptModal.vue'
 import IndexSwapPromptModal from '~/components/settings/IndexSwapPromptModal.vue'
 import { useMeiliClient } from '~/composables/useMeiliClient'
 import { useTask } from '~/composables/useTask'
-import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, usePromisifiedDialogs, useToasts } from '~/stores'
+import {
+  TOAST_FAILURE,
+  TOAST_PLEASEWAIT,
+  TOAST_SUCCESS,
+  useConfirmationDialog,
+  usePromisifiedDialogs,
+  useToasts,
+} from '~/stores'
 
 type RenameIndexOptions = {
   newIndexUid?: string
@@ -28,6 +36,7 @@ export const useIndexOperations = () => {
   const { t } = useI18n()
   const meili = useMeiliClient()
   const { openDialog } = usePromisifiedDialogs()
+  const { confirm } = useConfirmationDialog()
   const { createToast } = useToasts()
   const processTask = useTask()
 
@@ -191,5 +200,40 @@ export const useIndexOperations = () => {
     return targetIndexUid
   }
 
-  return { duplicateIndex, renameIndex, swapIndex }
+  const compactIndex = async (indexUid: string): Promise<void> => {
+    if (!(await confirm({ text: t('confirmations.compactIndex.text') }))) {
+      return
+    }
+
+    const toast = createToast({
+      ...TOAST_PLEASEWAIT(t),
+      title: t('toasts.titles.compactIndex', { indexUid }),
+    })
+
+    // The JS client (meilisearch@0.60.0) does not expose `compact()` yet, so we talk to the
+    // REST API directly through the client's `httpRequest` (same approach as useWebhooks).
+    // @see https://www.meilisearch.com/docs/reference/api/indexes/compact-index
+    const task = await processTask(
+      () => meili.httpRequest.post({ path: `indexes/${indexUid}/compact` }) as Promise<EnqueuedTask>,
+      {
+        onCanceled: () =>
+          toast.update({
+            ...TOAST_FAILURE(t),
+            text: t('toasts.texts.canceledTask'),
+          }),
+        onFailure: () =>
+          toast.update({
+            ...TOAST_FAILURE(t),
+            text: t('toasts.texts.failedTask'),
+          }),
+      },
+    )
+    if (task.status === 'failed') {
+      throw new Error('Failed to compact index')
+    }
+
+    toast.update({ ...TOAST_SUCCESS(t) })
+  }
+
+  return { duplicateIndex, renameIndex, swapIndex, compactIndex }
 }

--- a/app/pages/indexes/[indexUid]/settings/general-settings.vue
+++ b/app/pages/indexes/[indexUid]/settings/general-settings.vue
@@ -45,6 +45,27 @@
 
     <IndexSwapEditor :index-uid="indexUid" @error="self.error = $event" />
 
+    <template v-if="satisfiesVersion('>=1.23.0')">
+      <h3 class="inline-flex w-full items-center justify-between text-xl font-semibold">
+        {{ t('titles.compaction') }}
+      </h3>
+
+      <div class="space-y-2">
+        <p class="text-xs text-gray-600 italic">
+          {{ t('notices.compaction.text') }}
+        </p>
+        <Button
+          type="button"
+          :loading="self.isCompacting"
+          icon-on-right
+          theme="primary"
+          icon="heroicons:sparkles"
+          @click="compactIndex()">
+          {{ t('actions.compactIndex') }}
+        </Button>
+      </div>
+    </template>
+
     <h3 class="inline-flex w-full items-center justify-between text-xl font-semibold">
       {{ t('titles.dangerZone') }}
     </h3>
@@ -65,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import { TaskError, useFormSubmit, useMeiliClient, useTask } from '~/composables'
+import { TaskError, useFormSubmit, useIndexOperations, useMeiliClient, useTask } from '~/composables'
 import { TOAST_FAILURE, TOAST_SUCCESS, useToasts } from '~/stores/toasts'
 import Alert from '~/components/layout/Alert.vue'
 import Button from '~/components/layout/forms/Button.vue'
@@ -111,7 +132,20 @@ const processTask = useTask()
 const { createToast } = useToasts()
 const self = reactive({
   error: null as Error | null,
+  isCompacting: false,
 })
+
+const { compactIndex: doCompactIndex } = useIndexOperations()
+const compactIndex = async () => {
+  self.isCompacting = true
+  try {
+    await doCompactIndex(index.uid)
+  } catch (error) {
+    self.error = error as TaskError
+  } finally {
+    self.isCompacting = false
+  }
+}
 
 const dropIndex = async () => {
   const toast = createToast({
@@ -185,7 +219,11 @@ en:
     duplicateIndex: Duplicate index
     renameIndex: Rename index
     swapIndex: Swap index
+    compaction: Compaction
     dangerZone: Danger Zone
+  notices:
+    compaction:
+      text: Defragments the index's storage, reducing fragmentation that accumulates over time. This can significantly improve search and indexing performance, but may take a while depending on the index size.
   confirmations:
     dropIndex:
       title: "Drop `{index}`?"
@@ -203,4 +241,5 @@ en:
   actions:
     dropIndex: Delete index
     deleteAllDocuments: Delete all documents
+    compactIndex: Compact index
 </i18n>

--- a/app/pages/indexes/index.vue
+++ b/app/pages/indexes/index.vue
@@ -163,6 +163,10 @@ const swapIndex = async (indexUid: string) => {
   }
 }
 
+const { compactIndex } = useIndexOperations()
+
+const { satisfiesVersion } = useVersion()
+
 const indexMenuItems = (item: Index): DropdownMenuItem[] => [
   {
     label: t('actions.settings'),
@@ -184,6 +188,15 @@ const indexMenuItems = (item: Index): DropdownMenuItem[] => [
     icon: 'heroicons:arrows-right-left',
     onSelect: () => swapIndex(item.uid),
   },
+  ...(satisfiesVersion('>=1.23.0')
+    ? [
+        {
+          label: t('actions.compact'),
+          icon: 'heroicons:sparkles',
+          onSelect: () => compactIndex(item.uid),
+        },
+      ]
+    : []),
 ]
 
 const { indexes } = toRefs(self)
@@ -218,5 +231,6 @@ en:
     duplicate: Duplicate
     rename: Rename
     swap: Swap with…
+    compact: Compact
     openMenu: Open menu
 </i18n>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jwt-encode": "^1.0.1",
     "leaflet": "^1.9.4",
     "match-operator": "^0.3.1",
-    "meilisearch": "^0.59.0",
+    "meilisearch": "^0.60.0",
     "meilisearch-filters": "^1.1.0",
     "nuxt": "^4.4.8",
     "pinia": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6938,10 +6938,10 @@ meilisearch-filters@^1.1.0:
   resolved "https://registry.yarnpkg.com/meilisearch-filters/-/meilisearch-filters-1.1.0.tgz#fecc51c5e97239a328702b703e080f05a5ac3b5f"
   integrity sha512-CAUNisEDynkmXBLoZmpiolsskdOcpQ3m3OolZzclhx2QcB2Yj7b4irG6v9pUh/MQa2vAL7DgpoR8Qu+WbSYr+A==
 
-meilisearch@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.59.0.tgz#9b38d213a631e00fd9e61efd72b068a4a4ecdcf4"
-  integrity sha512-9KxasX98+qYhOVa4PPeaX/yY/ukM9DMuJlUJRgJVwrdCkWw+mkkiIh6EJmYyCxU8nXhj0VEzdYr3dNUJT1BQow==
+meilisearch@^0.60.0:
+  version "0.60.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.60.0.tgz#53b9f9741f66f3337121f809423d28af341f0bbe"
+  integrity sha512-z32KgxE6/7hRzbVfzUgzlmNl2OS7TwGE6wSWs2tVEuAY9DWrX6zAmt0s7wTyelH36orIaZ3/t1mQsCsExGtVDQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
- Adds the new [compaction endpoint](https://www.meilisearch.com/docs/reference/api/indexes/compact-index) (`POST /indexes/{indexUid}/compact`, Meilisearch >= 1.23), which defragments an index's LMDB storage.
- Available from the index's General settings page (new "Compaction" section) and from the index list's context menu ("Compact").
- Both entry points are gated behind `satisfiesVersion('>=1.23.0')` and require user confirmation before running.
- The official JS client (`meilisearch`) doesn't expose `compact()` yet — upgraded it to the latest `0.60.0` anyway, but still had to fall back to a raw `httpRequest.post()` call, same approach already used for webhooks and foreign keys in this codebase.

## Test plan
- [x] `yarn lint` / `yarn check` / `yarn build` pass
- [x] Manually tested against a local Meilisearch 1.53.1 instance: compaction from the index list context menu and from the settings page both enqueue an `indexCompaction` task that completes successfully (verified via `/tasks`)
- [x] Confirmation dialog and pending/success toast verified in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)