### PR TITLE
Feat: search personalization via Cohere reranking (Meilisearch >= 1.25)

### DIFF
--- a/app/components/documents/PersonalizeSearchControl.vue
+++ b/app/components/documents/PersonalizeSearchControl.vue
@@ -1,0 +1,47 @@
+<template>
+  <UPopover>
+    <button v-tippy="t('actions.toggle')" type="button">
+      <Icon
+        name="ph:identification-badge-fill"
+        :class="[
+          'size-6',
+          enabled ? 'text-primary-600 hover:text-primary-800' : 'text-gray-600 hover:text-gray-800',
+        ]" />
+    </button>
+
+    <template #content>
+      <div class="w-80 space-y-4 p-4">
+        <USwitch v-model="enabled" :label="t('labels.enable')" />
+
+        <div class="flex flex-col gap-1" :class="{ 'opacity-50': !enabled }">
+          <Label>{{ t('labels.userContext') }}</Label>
+          <Textarea
+            v-model="userContext"
+            :disabled="!enabled"
+            :placeholder="t('labels.userContextPlaceholder')"
+            :rows="4" />
+        </div>
+      </div>
+    </template>
+  </UPopover>
+</template>
+
+<script setup lang="ts">
+import Label from '~/components/layout/forms/Label.vue'
+import Textarea from '~/components/layout/forms/Textarea.vue'
+
+const enabled = defineModel<boolean>('enabled', { default: false })
+const userContext = defineModel<string>('userContext', { default: '' })
+
+const { t } = useI18n()
+</script>
+
+<i18n>
+en:
+  actions:
+    toggle: Search personalization
+  labels:
+    enable: Enable search personalization
+    userContext: User context
+    userContextPlaceholder: Describe the user (preferences, behavior, ...) to personalize results for them
+</i18n>

--- a/app/composables/useIndexLocalSettings.ts
+++ b/app/composables/useIndexLocalSettings.ts
@@ -17,6 +17,8 @@ type UseIndexLocalSettings = {
   showRankingScore: boolean
   showRankingScoreDetails: boolean
   showPerformanceDetails: boolean
+  personalizeEnabled: boolean
+  personalizeUserContext: string
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -31,6 +33,10 @@ const DEFAULT_HYBRID_SEMANTIC_RATIO = 0.5
 const DEFAULT_SHOW_RANKING_SCORE = false
 const DEFAULT_SHOW_RANKING_SCORE_DETAILS = false
 const DEFAULT_SHOW_PERFORMANCE_DETAILS = false
+// Personalization is opt-in for the same reason hybrid search is: it must never silently
+// change results for users who haven't asked for it.
+const DEFAULT_PERSONALIZE_ENABLED = false
+const DEFAULT_PERSONALIZE_USER_CONTEXT = ''
 
 export const useIndexLocalSettings = (indexUid: string) => {
   const { credentials } = useCredentials()
@@ -49,6 +55,8 @@ export const useIndexLocalSettings = (indexUid: string) => {
     showRankingScore: DEFAULT_SHOW_RANKING_SCORE,
     showRankingScoreDetails: DEFAULT_SHOW_RANKING_SCORE_DETAILS,
     showPerformanceDetails: DEFAULT_SHOW_PERFORMANCE_DETAILS,
+    personalizeEnabled: DEFAULT_PERSONALIZE_ENABLED,
+    personalizeUserContext: DEFAULT_PERSONALIZE_USER_CONTEXT,
   })
 
   const self = reactive({ storage })
@@ -114,6 +122,20 @@ export const useIndexLocalSettings = (indexUid: string) => {
       self.storage.hybridEnabled = DEFAULT_HYBRID_ENABLED
       self.storage.hybridEmbedder = DEFAULT_HYBRID_EMBEDDER
       self.storage.hybridSemanticRatio = DEFAULT_HYBRID_SEMANTIC_RATIO
+    },
+    personalizeEnabled: computed({
+      get: () => self.storage.personalizeEnabled ?? DEFAULT_PERSONALIZE_ENABLED,
+      set: (value: boolean) => (self.storage.personalizeEnabled = value),
+    }),
+    personalizeUserContext: computed({
+      get: () => self.storage.personalizeUserContext ?? DEFAULT_PERSONALIZE_USER_CONTEXT,
+      set: (value: string) => (self.storage.personalizeUserContext = value),
+    }),
+    // Call this when the server rejects a personalized search (e.g. the instance has no
+    // Cohere key configured) — resets both fields so the broken state can't be retried as-is.
+    resetPersonalize: () => {
+      self.storage.personalizeEnabled = DEFAULT_PERSONALIZE_ENABLED
+      self.storage.personalizeUserContext = DEFAULT_PERSONALIZE_USER_CONTEXT
     },
   }
 }

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -55,6 +55,11 @@
         v-model:show-ranking-score-details="showRankingScoreDetails"
         v-model:show-performance-details="showPerformanceDetails" />
 
+      <PersonalizeSearchControl
+        v-if="personalizeAvailable"
+        v-model:enabled="personalizeEnabled"
+        v-model:user-context="personalizeUserContext" />
+
       <button v-tippy="t('actions.documentView')" @click="viewMode = 'documents'">
         <Icon
           name="fa-solid:id-card"
@@ -132,8 +137,9 @@ import Button from '~/components/layout/forms/Button.vue'
 import DocumentsAsMap from '~/components/documents/DocumentsAsMap.vue'
 import HybridSearchControl from '~/components/documents/HybridSearchControl.vue'
 import DebugSearchControl from '~/components/documents/DebugSearchControl.vue'
+import PersonalizeSearchControl from '~/components/documents/PersonalizeSearchControl.vue'
 import { reactiveComputed } from '@vueuse/core'
-import { useVersion } from '~/stores'
+import { TOAST_FAILURE, useToasts, useVersion } from '~/stores'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -141,6 +147,11 @@ const indexUid = route.params.indexUid
 const meili = useMeiliClient()
 const tenant = useMultiTenancy()
 const { satisfiesVersion } = useVersion()
+const { createToast } = useToasts()
+// Search personalization requires Meilisearch >= 1.25. Unlike hybrid search's embedders,
+// there's no capability endpoint to probe whether the instance's Cohere key is actually
+// configured — that can only be discovered by a failing search, handled below.
+const personalizeAvailable = computed(() => satisfiesVersion('>=1.25.0'))
 const searchClient = reactiveComputed(() => (tenant.tenantToken ? useMeiliClient(tenant.tenantToken as string) : meili))
 const { formatDate } = useDateFormatter()
 const index = await tryOrThrow(() => meili.getIndex(indexUid as string))
@@ -167,6 +178,9 @@ const {
   showRankingScore,
   showRankingScoreDetails,
   showPerformanceDetails,
+  personalizeEnabled,
+  personalizeUserContext,
+  resetPersonalize,
 } = useIndexLocalSettings(index.uid)
 const appliedFilters = reactive(new AppliedFilters()) as AppliedFilters
 const searchTerms = ref('')
@@ -214,6 +228,11 @@ const searchParams = reactive({
   // Guarded here too (not just hidden in DebugSearchControl's UI) so a value persisted while
   // connected to a newer instance can't leak into a request against an older one.
   showPerformanceDetails: computed(() => showPerformanceDetails.value && satisfiesVersion('>=1.35.0')),
+  personalize: computed(() =>
+    personalizeAvailable.value && personalizeEnabled.value && personalizeUserContext.value.trim()
+      ? { userContext: personalizeUserContext.value }
+      : undefined,
+  ),
 })
 const resultset = ref(await tryOrThrow(() => searchClient.index(index.uid).search(null, searchParams)))
 
@@ -243,9 +262,23 @@ watch(searchTerms, () => (searchParams.offset = 0))
 watch(hybridEnabled, () => (searchParams.offset = 0))
 watch(hybridEmbedder, () => (searchParams.offset = 0))
 watch(hybridSemanticRatio, () => (searchParams.offset = 0))
+watch(personalizeEnabled, () => (searchParams.offset = 0))
+watch(personalizeUserContext, () => (searchParams.offset = 0))
 watch(
   searchParams,
-  async (searchParams) => (self.resultset = await searchClient.index(index.uid).search(null, searchParams)),
+  async (searchParams) => {
+    try {
+      self.resultset = await searchClient.index(index.uid).search(null, searchParams)
+    } catch (error) {
+      // There's no way to know ahead of time whether the instance's Cohere key is configured
+      // (see personalizeAvailable above) — a rejected personalized search is the only signal.
+      // Fall back to a plain search rather than leaving the page stuck on stale results.
+      if (!personalizeEnabled.value) throw error
+      resetPersonalize()
+      createToast({ ...TOAST_FAILURE(t), title: t('errors.personalizeFailed') })
+      self.resultset = await searchClient.index(index.uid).search(null, searchParams)
+    }
+  },
   { deep: true },
 )
 watch(resultset, () => (self.totalItems = self.resultset.estimatedTotalHits), {
@@ -274,4 +307,6 @@ en:
     filters: Sort & Filter
     multitenancyEnabled: Tenant preview
     search: Search...
+  errors:
+    personalizeFailed: Search personalization isn't configured on this instance. It has been turned off.
 </i18n>


### PR DESCRIPTION
## Summary
- Adds an opt-in "search personalization" control on the documents page (`PersonalizeSearchControl.vue`), mirroring the existing `HybridSearchControl` UX: a popover with an enable switch and a free-text "user context" field.
- Wires `personalize.userContext` into the search params, gated on `Meilisearch >= 1.25` (the version this feature — [dynamic reranking via Cohere](https://www.meilisearch.com/docs/capabilities/personalization/overview) — was introduced in).
- Since there's no capability endpoint to know ahead of time whether the instance's Cohere key is actually configured server-side, a rejected personalized search is caught, personalization is turned off, the search is retried without it, and a toast explains why.

## Test plan
- [x] `yarn lint` / `yarn run check` / `yarn build` all pass
- [x] Manually verified end-to-end against a local Meilisearch 1.53.1 instance (movies dataset, real Cohere key from `.env`): enabling personalization with a "romantic comedy fan who dislikes violence" context correctly reranks `Star Wars` below `Bride Wars` for query `wars`, versus the unpersonalized order
- [x] Verified the graceful-degradation path by pointing the instance at an invalid Cohere key: search falls back to unpersonalized results, personalization is auto-disabled, and the failure toast appears
- [ ] Manual review of the UI (popover placement/copy) in the actual app

🤖 Generated with [Claude Code](https://claude.com/claude-code)