### PR TITLE
Feat: index field details (Meilisearch 1.33+)

### DIFF
--- a/app/pages/indexes/[indexUid]/settings.vue
+++ b/app/pages/indexes/[indexUid]/settings.vue
@@ -129,6 +129,11 @@ const navigation: Array<NavigationItem> = reactive([
     text: t('menu.foreignKeys'),
   },
   {
+    href: `/indexes/${index.uid}/settings/fields`,
+    current: computed(() => 'indexes-indexUid-settings-fields' === route.name),
+    text: t('menu.fields'),
+  },
+  {
     href: `/indexes/${index.uid}/settings/local-settings`,
     current: computed(() => 'indexes-indexUid-settings-local-settings' === route.name),
     text: t('menu.localSettings'),
@@ -166,6 +171,7 @@ en:
     embedders: Embedders
     chat: Chat
     foreignKeys: Foreign Keys
+    fields: Fields
     localSettings: Local settings
   actions:
     documents: Go to Documents

--- a/app/pages/indexes/[indexUid]/settings.vue
+++ b/app/pages/indexes/[indexUid]/settings.vue
@@ -27,7 +27,7 @@
 import { NuxtLink, NuxtPage } from '#components'
 import { onMounted } from 'vue'
 import { useMeiliClient } from '~/composables'
-import { useChatAvailability } from '~/stores'
+import { useChatAvailability, useVersion } from '~/stores'
 import { safeToRefs, tryOrThrow } from '~/utils'
 import humanizeString from 'humanize-string'
 
@@ -36,6 +36,7 @@ const route = useRoute()
 const indexUid = route.params.indexUid
 const meili = useMeiliClient()
 const { available: chatAvailable } = safeToRefs(useChatAvailability())
+const { satisfiesVersion } = useVersion()
 const index = await tryOrThrow(() => meili.getIndex(indexUid as string))
 
 type NavigationItem = {
@@ -51,6 +52,12 @@ const navigation: Array<NavigationItem> = reactive([
     href: `/indexes/${index.uid}/settings/general-settings`,
     current: computed(() => 'indexes-indexUid-settings-general-settings' === route.name),
     text: t('menu.generalSettings'),
+  },
+  {
+    href: `/indexes/${index.uid}/settings/fields`,
+    current: computed(() => 'indexes-indexUid-settings-fields' === route.name),
+    visible: computed(() => satisfiesVersion('>=1.33.0')),
+    text: t('menu.fields'),
   },
   {
     href: `/indexes/${index.uid}/settings/import-documents`,
@@ -127,11 +134,6 @@ const navigation: Array<NavigationItem> = reactive([
     href: `/indexes/${index.uid}/settings/foreign-keys`,
     current: computed(() => 'indexes-indexUid-settings-foreign-keys' === route.name),
     text: t('menu.foreignKeys'),
-  },
-  {
-    href: `/indexes/${index.uid}/settings/fields`,
-    current: computed(() => 'indexes-indexUid-settings-fields' === route.name),
-    text: t('menu.fields'),
   },
   {
     href: `/indexes/${index.uid}/settings/local-settings`,

--- a/app/pages/indexes/[indexUid]/settings/fields.vue
+++ b/app/pages/indexes/[indexUid]/settings/fields.vue
@@ -17,14 +17,67 @@
         {{ self.error }}
       </Alert>
 
-      <div class="flex flex-wrap items-end gap-3">
-        <UFormField :label="t('filters.pattern')" class="min-w-56 flex-1">
-          <UInput v-model="self.pattern" :placeholder="t('filters.patternPlaceholder')" class="w-full" />
-        </UFormField>
+      <div class="flex flex-wrap items-center gap-3">
+        <UInput
+          v-model="self.pattern"
+          icon="i-lucide-search"
+          :placeholder="t('filters.patternPlaceholder')"
+          class="min-w-56 flex-1" />
 
-        <UFormField v-for="key in booleanFilterKeys" :key="key" :label="t(`filters.labels.${key}`)">
-          <USelect v-model="self.filters[key]" :items="triStateItems" class="w-32" />
-        </UFormField>
+        <UPopover>
+          <UChip v-if="activeBooleanFilterKeys.length > 0" :text="activeBooleanFilterKeys.length" size="sm">
+            <UButton
+              color="neutral"
+              variant="outline"
+              icon="i-lucide-sliders-horizontal"
+              :label="t('filters.button')" />
+          </UChip>
+          <UButton
+            v-else
+            color="neutral"
+            variant="outline"
+            icon="i-lucide-sliders-horizontal"
+            :label="t('filters.button')" />
+
+          <template #content>
+            <div class="w-72 space-y-3 p-4">
+              <div v-for="key in booleanFilterKeys" :key="key" class="flex items-center justify-between gap-3">
+                <span class="text-sm">{{ t(`filters.labels.${key}`) }}</span>
+                <UFieldGroup size="xs">
+                  <UButton
+                    v-for="option in triStateItems"
+                    :key="option.value"
+                    :label="option.label"
+                    :color="option.value === self.filters[key] ? 'primary' : 'neutral'"
+                    :variant="option.value === self.filters[key] ? 'solid' : 'outline'"
+                    @click="self.filters[key] = option.value" />
+                </UFieldGroup>
+              </div>
+
+              <UButton
+                v-if="activeBooleanFilterKeys.length > 0"
+                color="neutral"
+                variant="ghost"
+                size="xs"
+                :label="t('filters.reset')"
+                class="w-full justify-center"
+                @click="resetBooleanFilters" />
+            </div>
+          </template>
+        </UPopover>
+      </div>
+
+      <div v-if="activeBooleanFilterKeys.length > 0" class="flex flex-wrap items-center gap-2">
+        <UBadge
+          v-for="key in activeBooleanFilterKeys"
+          :key="key"
+          color="neutral"
+          variant="subtle"
+          class="cursor-pointer gap-1"
+          @click="self.filters[key] = ANY">
+          {{ t(`filters.labels.${key}`) }}: {{ 'true' === self.filters[key] ? t('filters.yes') : t('filters.no') }}
+          <Icon name="mdi:close" class="size-3" />
+        </UBadge>
       </div>
 
       <Table
@@ -171,6 +224,11 @@ const self = reactive({
   lastPage,
 })
 
+const activeBooleanFilterKeys = computed(() => booleanFilterKeys.filter((key) => ANY !== self.filters[key]))
+const resetBooleanFilters = () => {
+  for (const key of booleanFilterKeys) self.filters[key] = ANY
+}
+
 const buildFilter = (): FieldsFilter | undefined => {
   const booleanFilters: Partial<Record<BooleanFilterKey, boolean>> = {}
   for (const key of booleanFilterKeys) {
@@ -230,8 +288,9 @@ en:
     title: Field details are not available
     text: 'Listing field details requires Meilisearch {version}. This instance runs an older version.'
   filters:
-    pattern: Attribute / Pattern
     patternPlaceholder: "e.g. genre or price.*"
+    button: Filters
+    reset: Reset filters
     any: Any
     yes: 'Yes'
     no: 'No'

--- a/app/pages/indexes/[indexUid]/settings/fields.vue
+++ b/app/pages/indexes/[indexUid]/settings/fields.vue
@@ -118,10 +118,14 @@
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
           <td class="align-top">
-            <span v-if="item.filterable?.enabled" class="inline-flex items-start gap-1.5">
+            <div v-if="item.filterable?.enabled" class="inline-flex items-start gap-1.5">
               <Icon name="mdi:check" class="mt-0.5 shrink-0 text-green-600" />
-              <span class="text-xs text-gray-500">{{ filterableDetails(item.filterable) }}</span>
-            </span>
+              <ul class="space-y-1 text-xs text-gray-500">
+                <li v-for="feature of filterableDetails(item.filterable)">
+                  <UBadge color="neutral" variant="outline">{{ feature }}</UBadge>
+                </li>
+              </ul>
+            </div>
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
           <td class="align-top">
@@ -184,7 +188,7 @@ const ANY = 'any'
 type TriState = typeof ANY | 'true' | 'false'
 const toBool = (value: TriState): boolean | undefined => (ANY === value ? undefined : 'true' === value)
 
-const triStateItems = computed(() => [
+const triStateItems = computed<Array<{ label: string; value: TriState }>>(() => [
   { label: t('filters.any'), value: ANY },
   { label: t('filters.yes'), value: 'true' },
   { label: t('filters.no'), value: 'false' },
@@ -219,9 +223,7 @@ const filterableDetails = (filterable: NonNullable<IndexField['filterable']>) =>
     filterable.facetSearch ? t('badges.facetSearch') : null,
     filterable.equality ? t('badges.equality') : null,
     filterable.comparison ? t('badges.comparison') : null,
-  ]
-    .filter(Boolean)
-    .join(' · ')
+  ].filter(Boolean)
 
 const buildFilter = (): FieldsFilter | undefined => {
   const booleanFilters: Partial<Record<BooleanFilterKey, boolean>> = {}

--- a/app/pages/indexes/[indexUid]/settings/fields.vue
+++ b/app/pages/indexes/[indexUid]/settings/fields.vue
@@ -18,24 +18,13 @@
       </Alert>
 
       <div class="flex flex-wrap items-end gap-3">
-        <UniqueId v-slot="{ id }" as="div" class="min-w-56 flex-1 space-y-1 *:block">
-          <Label :for="id">{{ t('filters.pattern') }}</Label>
-          <input
-            :id
-            v-model="self.pattern"
-            type="text"
-            class="form-input w-full text-sm"
-            :placeholder="t('filters.patternPlaceholder')" />
-        </UniqueId>
+        <UFormField :label="t('filters.pattern')" class="min-w-56 flex-1">
+          <UInput v-model="self.pattern" :placeholder="t('filters.patternPlaceholder')" class="w-full" />
+        </UFormField>
 
-        <UniqueId v-for="key in booleanFilterKeys" :key="key" v-slot="{ id }" as="div" class="space-y-1 *:block">
-          <Label :for="id">{{ t(`filters.labels.${key}`) }}</Label>
-          <select :id v-model="self.filters[key]" class="form-input text-sm">
-            <option value="">{{ t('filters.any') }}</option>
-            <option value="true">{{ t('filters.yes') }}</option>
-            <option value="false">{{ t('filters.no') }}</option>
-          </select>
-        </UniqueId>
+        <UFormField v-for="key in booleanFilterKeys" :key="key" :label="t(`filters.labels.${key}`)">
+          <USelect v-model="self.filters[key]" :items="triStateItems" class="w-32" />
+        </UFormField>
       </div>
 
       <Table
@@ -134,8 +123,6 @@ import Alert from '~/components/layout/Alert.vue'
 import Badge from '~/components/layout/Badge.vue'
 import Table from '~/components/layout/tables/Table.vue'
 import PageSize from '~/components/layout/pagination/PageSize.vue'
-import UniqueId from '~/components/UniqueId.vue'
-import Label from '~/components/layout/forms/Label.vue'
 import { tryOrThrow } from '~/utils'
 
 type Props = {
@@ -154,8 +141,17 @@ const available = computed(() => satisfiesVersion(FIELDS_MIN_VERSION))
 
 const booleanFilterKeys = ['displayed', 'searchable', 'sortable', 'distinct', 'rankingRule', 'filterable'] as const
 type BooleanFilterKey = (typeof booleanFilterKeys)[number]
-type TriState = '' | 'true' | 'false'
-const toBool = (value: TriState): boolean | undefined => ('' === value ? undefined : 'true' === value)
+
+/** `USelect` reserves the empty string for "no selection", so "any" needs its own sentinel. */
+const ANY = 'any'
+type TriState = typeof ANY | 'true' | 'false'
+const toBool = (value: TriState): boolean | undefined => (ANY === value ? undefined : 'true' === value)
+
+const triStateItems = computed(() => [
+  { label: t('filters.any'), value: ANY },
+  { label: t('filters.yes'), value: 'true' },
+  { label: t('filters.no'), value: 'false' },
+])
 
 const itemsPerPage = ref(20)
 const { offset, totalItems, currentPage, lastPage } = usePagination(itemsPerPage)
@@ -163,7 +159,7 @@ const { offset, totalItems, currentPage, lastPage } = usePagination(itemsPerPage
 const self = reactive({
   error: null as string | null,
   pattern: '',
-  filters: Object.fromEntries(booleanFilterKeys.map((key) => [key, '' as TriState])) as Record<
+  filters: Object.fromEntries(booleanFilterKeys.map((key) => [key, ANY as TriState])) as Record<
     BooleanFilterKey,
     TriState
   >,

--- a/app/pages/indexes/[indexUid]/settings/fields.vue
+++ b/app/pages/indexes/[indexUid]/settings/fields.vue
@@ -1,0 +1,263 @@
+<template>
+  <section class="space-y-4">
+    <h3 class="inline-flex w-full items-start justify-between">
+      <span class="inline-flex flex-col gap-1">
+        <span class="text-xl font-semibold">{{ t('title') }}</span>
+        <span class="text-sm text-gray-600 italic">{{ t('description') }}</span>
+      </span>
+      <DocumentationLink href="https://www.meilisearch.com/docs/reference/api/indexes/list-index-fields" />
+    </h3>
+
+    <Alert v-if="!available" theme="warning" :title="t('unavailable.title')">
+      {{ t('unavailable.text', { version: FIELDS_MIN_VERSION }) }}
+    </Alert>
+
+    <template v-else>
+      <Alert v-if="self.error" dismissable theme="danger" @close="self.error = null">
+        {{ self.error }}
+      </Alert>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <UniqueId v-slot="{ id }" as="div" class="min-w-56 flex-1 space-y-1 *:block">
+          <Label :for="id">{{ t('filters.pattern') }}</Label>
+          <input
+            :id
+            v-model="self.pattern"
+            type="text"
+            class="form-input w-full text-sm"
+            :placeholder="t('filters.patternPlaceholder')" />
+        </UniqueId>
+
+        <UniqueId v-for="key in booleanFilterKeys" :key="key" v-slot="{ id }" as="div" class="space-y-1 *:block">
+          <Label :for="id">{{ t(`filters.labels.${key}`) }}</Label>
+          <select :id v-model="self.filters[key]" class="form-input text-sm">
+            <option value="">{{ t('filters.any') }}</option>
+            <option value="true">{{ t('filters.yes') }}</option>
+            <option value="false">{{ t('filters.no') }}</option>
+          </select>
+        </UniqueId>
+      </div>
+
+      <Table
+        :items="self.fields.results"
+        :columns="[
+          t('columns.field'),
+          t('columns.displayed'),
+          t('columns.searchable'),
+          t('columns.sortable'),
+          t('columns.distinct'),
+          t('columns.rankingRule'),
+          t('columns.filterable'),
+          t('columns.localized'),
+        ]">
+        <template #default="{ item }">
+          <td class="font-mono text-xs font-medium">{{ item.name }}</td>
+          <td class="text-center">
+            <Icon v-if="item.displayed?.enabled" name="mdi:check" class="text-green-600" />
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+          <td class="text-center">
+            <Icon v-if="item.searchable?.enabled" name="mdi:check" class="text-green-600" />
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+          <td class="text-center">
+            <Icon v-if="item.sortable?.enabled" name="mdi:check" class="text-green-600" />
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+          <td class="text-center">
+            <Icon v-if="item.distinct?.enabled" name="mdi:check" class="text-green-600" />
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+          <td class="text-center">
+            <span v-if="item.rankingRule?.enabled" class="inline-flex items-center gap-1">
+              <Icon name="mdi:check" class="text-green-600" />
+              <Badge v-if="item.rankingRule.order" theme="neutral" class="text-xs">
+                {{ item.rankingRule.order }}
+              </Badge>
+            </span>
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+          <td>
+            <span v-if="item.filterable?.enabled" class="inline-flex flex-wrap items-center gap-1">
+              <Icon name="mdi:check" class="text-green-600" />
+              <Badge v-if="item.filterable.sortBy" theme="neutral" class="text-xs">
+                {{ t('badges.sortBy', { value: item.filterable.sortBy }) }}
+              </Badge>
+              <Badge v-if="item.filterable.facetSearch" theme="neutral" class="text-xs">
+                {{ t('badges.facetSearch') }}
+              </Badge>
+              <Badge v-if="item.filterable.equality" theme="neutral" class="text-xs">
+                {{ t('badges.equality') }}
+              </Badge>
+              <Badge v-if="item.filterable.comparison" theme="neutral" class="text-xs">
+                {{ t('badges.comparison') }}
+              </Badge>
+            </span>
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+          <td>
+            <span v-if="item.localized?.locales?.length" class="inline-flex flex-wrap gap-1">
+              <Badge v-for="locale in item.localized.locales" :key="locale" theme="neutral" class="text-xs">
+                {{ locale }}
+              </Badge>
+            </span>
+            <Icon v-else name="mdi:minus" class="text-gray-300" />
+          </td>
+        </template>
+      </Table>
+
+      <div v-if="0 === self.fields.results.length" class="py-8 text-center text-sm text-gray-400 italic">
+        {{ t('emptyState') }}
+      </div>
+
+      <div class="flex items-center justify-between">
+        <PageSize v-model="itemsPerPage" />
+        <UPagination
+          :page="currentPage"
+          :total="lastPage"
+          :items-per-page="1"
+          :sibling-count="2"
+          active-color="primary"
+          variant="ghost"
+          @update:page="handlePageChange" />
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { watchDebounced } from '@vueuse/core'
+import type { FieldsFilter, FieldsResults } from 'meilisearch'
+import { usePagination } from '~/composables'
+import DocumentationLink from '~/components/layout/DocumentationLink.vue'
+import Alert from '~/components/layout/Alert.vue'
+import Badge from '~/components/layout/Badge.vue'
+import Table from '~/components/layout/tables/Table.vue'
+import PageSize from '~/components/layout/pagination/PageSize.vue'
+import UniqueId from '~/components/UniqueId.vue'
+import Label from '~/components/layout/forms/Label.vue'
+import { tryOrThrow } from '~/utils'
+
+type Props = {
+  indexUid: string
+}
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const meili = useMeiliClient()
+const index = meili.index(props.indexUid)
+const { satisfiesVersion } = useVersion()
+
+/** The `POST /indexes/{indexUid}/fields` endpoint landed in Meilisearch 1.33. */
+const FIELDS_MIN_VERSION = '>=1.33.0'
+const available = computed(() => satisfiesVersion(FIELDS_MIN_VERSION))
+
+const booleanFilterKeys = ['displayed', 'searchable', 'sortable', 'distinct', 'rankingRule', 'filterable'] as const
+type BooleanFilterKey = (typeof booleanFilterKeys)[number]
+type TriState = '' | 'true' | 'false'
+const toBool = (value: TriState): boolean | undefined => ('' === value ? undefined : 'true' === value)
+
+const itemsPerPage = ref(20)
+const { offset, totalItems, currentPage, lastPage } = usePagination(itemsPerPage)
+
+const self = reactive({
+  error: null as string | null,
+  pattern: '',
+  filters: Object.fromEntries(booleanFilterKeys.map((key) => [key, '' as TriState])) as Record<
+    BooleanFilterKey,
+    TriState
+  >,
+  fields: { results: [], offset: 0, limit: 0, total: 0 } as FieldsResults,
+  totalItems,
+  offset,
+  itemsPerPage,
+  currentPage,
+  lastPage,
+})
+
+const buildFilter = (): FieldsFilter | undefined => {
+  const booleanFilters: Partial<Record<BooleanFilterKey, boolean>> = {}
+  for (const key of booleanFilterKeys) {
+    const value = toBool(self.filters[key])
+    if (undefined !== value) {
+      booleanFilters[key] = value
+    }
+  }
+  const pattern = self.pattern.trim()
+  const filter: FieldsFilter = {
+    ...booleanFilters,
+    ...(pattern ? { attributePatterns: [pattern] } : {}),
+  }
+  return Object.keys(filter).length > 0 ? filter : undefined
+}
+
+const fetchFields = () =>
+  tryOrThrow(async () => {
+    const result = await index.getFields({ offset: self.offset, limit: self.itemsPerPage, filter: buildFilter() })
+    self.totalItems = result.total
+    return result
+  })
+
+const refetch = async () => {
+  if (!available.value) {
+    return
+  }
+  self.error = null
+  self.fields = await fetchFields()
+}
+
+watch(offset, refetch)
+watch(itemsPerPage, refetch)
+watch(available, (isAvailable) => isAvailable && refetch(), { immediate: true })
+watchDebounced(
+  [() => self.pattern, () => self.filters],
+  async () => {
+    self.offset = 0
+    await refetch()
+  },
+  { debounce: 300, deep: true },
+)
+
+const handlePageChange = (page: number) => (self.offset = (page - 1) * self.itemsPerPage)
+
+useHead({
+  title: `${t('title')} - ${index.uid}`,
+})
+</script>
+
+<i18n>
+en:
+  title: Fields
+  description: Detailed metadata about every field in this index — display, search, filtering and localization settings.
+  emptyState: No fields match your filters.
+  unavailable:
+    title: Field details are not available
+    text: 'Listing field details requires Meilisearch {version}. This instance runs an older version.'
+  filters:
+    pattern: Attribute / Pattern
+    patternPlaceholder: "e.g. genre or price.*"
+    any: Any
+    yes: 'Yes'
+    no: 'No'
+    labels:
+      displayed: Displayed
+      searchable: Searchable
+      sortable: Sortable
+      distinct: Distinct
+      rankingRule: Ranking rule
+      filterable: Filterable
+  columns:
+    field: Field
+    displayed: Displayed
+    searchable: Searchable
+    sortable: Sortable
+    distinct: Distinct
+    rankingRule: Ranking Rule
+    filterable: Filterable
+    localized: Localized
+  badges:
+    sortBy: 'sortBy: {value}'
+    facetSearch: facet search
+    equality: equality
+    comparison: comparison
+</i18n>

--- a/app/pages/indexes/[indexUid]/settings/fields.vue
+++ b/app/pages/indexes/[indexUid]/settings/fields.vue
@@ -93,55 +93,40 @@
           t('columns.localized'),
         ]">
         <template #default="{ item }">
-          <td class="font-mono text-xs font-medium">{{ item.name }}</td>
-          <td class="text-center">
+          <td class="align-top font-mono text-xs font-medium">{{ item.name }}</td>
+          <td class="text-center align-top">
             <Icon v-if="item.displayed?.enabled" name="mdi:check" class="text-green-600" />
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
-          <td class="text-center">
+          <td class="text-center align-top">
             <Icon v-if="item.searchable?.enabled" name="mdi:check" class="text-green-600" />
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
-          <td class="text-center">
+          <td class="text-center align-top">
             <Icon v-if="item.sortable?.enabled" name="mdi:check" class="text-green-600" />
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
-          <td class="text-center">
+          <td class="text-center align-top">
             <Icon v-if="item.distinct?.enabled" name="mdi:check" class="text-green-600" />
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
-          <td class="text-center">
-            <span v-if="item.rankingRule?.enabled" class="inline-flex items-center gap-1">
-              <Icon name="mdi:check" class="text-green-600" />
-              <Badge v-if="item.rankingRule.order" theme="neutral" class="text-xs">
-                {{ item.rankingRule.order }}
-              </Badge>
+          <td class="align-top">
+            <span v-if="item.rankingRule?.enabled" class="inline-flex items-center gap-1.5">
+              <Icon name="mdi:check" class="shrink-0 text-green-600" />
+              <span v-if="item.rankingRule.order" class="text-xs text-gray-500">{{ item.rankingRule.order }}</span>
             </span>
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
-          <td>
-            <span v-if="item.filterable?.enabled" class="inline-flex flex-wrap items-center gap-1">
-              <Icon name="mdi:check" class="text-green-600" />
-              <Badge v-if="item.filterable.sortBy" theme="neutral" class="text-xs">
-                {{ t('badges.sortBy', { value: item.filterable.sortBy }) }}
-              </Badge>
-              <Badge v-if="item.filterable.facetSearch" theme="neutral" class="text-xs">
-                {{ t('badges.facetSearch') }}
-              </Badge>
-              <Badge v-if="item.filterable.equality" theme="neutral" class="text-xs">
-                {{ t('badges.equality') }}
-              </Badge>
-              <Badge v-if="item.filterable.comparison" theme="neutral" class="text-xs">
-                {{ t('badges.comparison') }}
-              </Badge>
+          <td class="align-top">
+            <span v-if="item.filterable?.enabled" class="inline-flex items-start gap-1.5">
+              <Icon name="mdi:check" class="mt-0.5 shrink-0 text-green-600" />
+              <span class="text-xs text-gray-500">{{ filterableDetails(item.filterable) }}</span>
             </span>
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
-          <td>
-            <span v-if="item.localized?.locales?.length" class="inline-flex flex-wrap gap-1">
-              <Badge v-for="locale in item.localized.locales" :key="locale" theme="neutral" class="text-xs">
-                {{ locale }}
-              </Badge>
+          <td class="align-top">
+            <span v-if="item.localized?.locales?.length" class="text-xs text-gray-500">
+              {{ item.localized.locales.join(', ') }}
             </span>
             <Icon v-else name="mdi:minus" class="text-gray-300" />
           </td>
@@ -169,11 +154,10 @@
 
 <script setup lang="ts">
 import { watchDebounced } from '@vueuse/core'
-import type { FieldsFilter, FieldsResults } from 'meilisearch'
+import type { FieldsFilter, FieldsResults, IndexField } from 'meilisearch'
 import { usePagination } from '~/composables'
 import DocumentationLink from '~/components/layout/DocumentationLink.vue'
 import Alert from '~/components/layout/Alert.vue'
-import Badge from '~/components/layout/Badge.vue'
 import Table from '~/components/layout/tables/Table.vue'
 import PageSize from '~/components/layout/pagination/PageSize.vue'
 import { tryOrThrow } from '~/utils'
@@ -228,6 +212,16 @@ const activeBooleanFilterKeys = computed(() => booleanFilterKeys.filter((key) =>
 const resetBooleanFilters = () => {
   for (const key of booleanFilterKeys) self.filters[key] = ANY
 }
+
+const filterableDetails = (filterable: NonNullable<IndexField['filterable']>) =>
+  [
+    filterable.sortBy ? t('badges.sortBy', { value: filterable.sortBy }) : null,
+    filterable.facetSearch ? t('badges.facetSearch') : null,
+    filterable.equality ? t('badges.equality') : null,
+    filterable.comparison ? t('badges.comparison') : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
 
 const buildFilter = (): FieldsFilter | undefined => {
   const booleanFilters: Partial<Record<BooleanFilterKey, boolean>> = {}


### PR DESCRIPTION
## Summary
- Add a read-only "Fields" tab to index settings, backed by the new `POST /indexes/{indexUid}/fields` endpoint (Meilisearch 1.33+): displayed/searchable/sortable/distinct/rankingRule/filterable/localized metadata per field.
- Attribute-pattern search plus per-capability boolean filters (Displayed/Searchable/Sortable/Distinct/Ranking rule/Filterable), with pagination.
- Version-gated via `satisfiesVersion('>=1.33.0')`; shows a fallback alert on older instances instead of erroring.

## Test plan
- [x] `yarn lint` / `yarn check` pass
- [x] Manually verified against a local Meilisearch 1.53.1 instance seeded with the `movies` dataset:
  - [x] Fields tab renders the table with correct badges/checkmarks for displayed/searchable/sortable/distinct/rankingRule/filterable/localized
  - [x] Attribute pattern search (with wildcard) filters correctly
  - [x] Boolean filters (e.g. Filterable = No) filter correctly, including combined with pattern search
  - [x] Pagination controls present and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)