### PR TITLE
Fix: indefinite toasts no longer feed Infinity to reka-ui's ProgressRoot

### DIFF
--- a/app/stores/toasts.ts
+++ b/app/stores/toasts.ts
@@ -46,25 +46,23 @@ export const useToasts = defineStore('toasts', () => {
   const nuxtToasts = useToast()
 
   // Adapt the historical toast options to Nuxt UI's toast props
-  const toToastProps = (options: CreateToastOptions) => {
-    const indefinite = 0 === (options.ttl ?? TOAST_DEFAULT_TTL)
-    return {
-      title: options.title,
-      description: options.text,
-      icon: options.icon,
-      duration: indefinite ? Infinity : options.ttl ?? TOAST_DEFAULT_TTL,
-      // An indefinite toast has no "time remaining" to show. Nuxt UI's toast progress bar
-      // computes `remaining / duration`, which is `Infinity / Infinity` (NaN) once duration
-      // is Infinity — disable it here rather than let it feed NaN into reka-ui's ProgressRoot.
-      progress: !indefinite,
-      close: options.dismissable ?? true,
-      ui: {
-        icon: ['size-6', ...(Array.isArray(options.iconClasses) ? options.iconClasses : [options.iconClasses ?? ''])]
-          .join(' ')
-          .trim(),
-      },
-    }
-  }
+  const toToastProps = (options: CreateToastOptions) => ({
+    title: options.title,
+    description: options.text,
+    icon: options.icon,
+    // A `ttl` of 0 means "indefinite", and reka-ui's ToastRoot starts no auto-close timer for a
+    // duration of 0 — just like Infinity. Prefer 0: ToastRoot only refreshes its `remaining` time
+    // from a requestAnimationFrame loop, so it lags one render behind a duration change. Coming
+    // from Infinity, the toast progress bar was fed `Infinity / newDuration * 100` and ProgressRoot
+    // rejected it; coming from 0, the stale value fails the `remaining > 0` guard it sits behind.
+    duration: options.ttl ?? TOAST_DEFAULT_TTL,
+    close: options.dismissable ?? true,
+    ui: {
+      icon: ['size-6', ...(Array.isArray(options.iconClasses) ? options.iconClasses : [options.iconClasses ?? ''])]
+        .join(' ')
+        .trim(),
+    },
+  })
 
   const createToast = (options: CreateToastOptions): Toast => {
     const id = ulid()


### PR DESCRIPTION
## Problem

Every `TOAST_PLEASEWAIT` toast logged one console error when it resolved:

```
[error] Invalid prop `value` of value `Infinity` supplied to `ProgressRoot`. […] Defaulting to `null`.
```

Reproducible on any page that saves through a toast (`/webhooks`, `/experimental-features`, `/search-rules`, …).

## Root cause

The error does **not** come from the indefinite toast itself — it comes from the `update()` that turns it into a success/failure toast.

In `reka-ui`'s `ToastRootImpl`, `remainingTime` is a `ref` refreshed **only** from a `useRafFn` loop:

- with `duration: Infinity` it stays pinned at `Infinity` (`Infinity - elapsed === Infinity`)
- when `duration` switches to `5000`, the `duration` computed updates immediately but `remainingTime` waits for the next animation frame — and Vue re-renders before that
- `Toast.vue` then computes `remaining / totalDuration * 100` = `Infinity / 5000 * 100` = **`Infinity`**

Measured: the error fires 88 ms *after* the PATCH response completes, and never during the indefinite phase.

The `progress: !indefinite` guard added in 581e711 could not help — by the time of the offending render the toast has already switched back to `progress: true`. Its comment also mis-stated the mechanism (`Infinity / Infinity` → `NaN`); the rejected value is `Infinity`.

## Fix

Use `duration: 0` instead of `Infinity`.

`startTimer()` treats `duration <= 0` exactly like `Infinity` (no auto-close timer → the toast stays up), but `remainingTime` is then `0` — and `Toast.vue`'s `v-if` already contains `remaining > 0`. The stale value now fails that guard instead of reaching `ProgressRoot`.

The mapping collapses to `duration: options.ttl ?? TOAST_DEFAULT_TTL` and the `progress` workaround goes away: the fix removes code rather than adding timing workarounds.

Notably, all 33 `createToast` call sites go through `TOAST_PLEASEWAIT` then `update()` — so simply disabling `progress` would have removed the progress bar from every toast in the app. This keeps it.

## Verification

Manual, against a live Meilisearch instance:

| Test | Result |
|---|---|
| Repro before the fix | 1 `Infinity` error, timed on the `update()` |
| Same scenario after the fix | **0 errors, 0 warnings** |
| Indefinite toast (`ttl: 0`) | still displayed after 9 s ✅ |
| Chained `pleaseWait → pleaseWait → success` | 0 errors ✅ |
| Finite toast | still auto-closes after 5 s ✅ |
| Progress bar | preserved — visible and animating on finite toasts, absent on indefinite ones |

`yarn lint` and `yarn run check` pass.

## Upstream

The underlying issue is in `@nuxt/ui`: `Toast.vue` does not clamp `remaining / totalDuration * 100`. Worth an upstream issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)