### PR TITLE
Feat: view, edit and delete a document from the search results

### DIFF
--- a/app/components/documents/DocumentCard.vue
+++ b/app/components/documents/DocumentCard.vue
@@ -19,11 +19,13 @@
               {{ primaryKey }}
             </dt>
             <dd class="table-cell text-justify text-sm font-semibold text-gray-800 @xl:p-1">
-              <ValueRenderer
-                :index-uid="indexUid"
-                :field="primaryKey as string"
-                :value="document[primaryKey]"
-                :level="0" />
+              <DocumentIdLink :document-id="document[primaryKey]">
+                <ValueRenderer
+                  :index-uid="indexUid"
+                  :field="primaryKey as string"
+                  :value="document[primaryKey]"
+                  :level="0" />
+              </DocumentIdLink>
             </dd>
           </div>
           <template v-for="key of fieldsWithoutPrimaryKey">
@@ -49,6 +51,7 @@
 
 <script setup lang="ts">
 import ValueRenderer from './ValueRenderer.vue'
+import DocumentIdLink from './DocumentIdLink.vue'
 import { useFields } from '~/composables'
 import { looksLikeAPictureUrl } from '~/utils'
 

--- a/app/components/documents/DocumentIdLink.vue
+++ b/app/components/documents/DocumentIdLink.vue
@@ -1,0 +1,30 @@
+<template>
+  <button
+    v-if="openDocument"
+    type="button"
+    v-tippy="t('actions.open')"
+    class="cursor-pointer underline decoration-dotted underline-offset-4 hover:text-primary-600"
+    @click="openDocument(documentId)">
+    <slot />
+  </button>
+  <slot v-else />
+</template>
+
+<script setup lang="ts">
+import { useDocumentViewer, type DocumentId } from '~/composables'
+
+type Props = {
+  documentId: DocumentId
+}
+
+defineProps<Props>()
+
+const { t } = useI18n()
+const openDocument = useDocumentViewer()
+</script>
+
+<i18n>
+en:
+  actions:
+    open: View, edit or delete this document
+</i18n>

--- a/app/components/documents/DocumentSlideOver.vue
+++ b/app/components/documents/DocumentSlideOver.vue
@@ -1,0 +1,170 @@
+<template>
+  <USlideover
+    v-model:open="open"
+    :title="`${primaryKey}: ${documentId}`"
+    :description="indexUid"
+    side="right"
+    :overlay="false"
+    :dismissible="!loading"
+    :ui="{ content: 'max-w-5xl', title: 'text-2xl font-semibold' }">
+    <template #body>
+      <form class="flex h-full flex-col gap-4" @reset.prevent="reset()" @submit.prevent="save()">
+        <Alert v-if="error" dismissable theme="danger" @close="error = null">
+          {{ error }}
+        </Alert>
+
+        <p v-if="fetching" class="text-sm font-light text-gray-500 italic">{{ t('loading') }}</p>
+
+        <JsonEditorVue v-else v-model="json" mode="text" :read-only="loading" class="json-editor min-h-0 flex-1" />
+
+        <footer class="flex flex-col items-center justify-between gap-4 sm:flex-row">
+          <Button
+            type="button"
+            icon="heroicons:trash"
+            :disabled="fetching || loading"
+            :loading="'delete' === pendingAction"
+            class="hover:text-red-600"
+            @click="remove()">
+            {{ t('actions.delete') }}
+          </Button>
+          <Buttons>
+            <Button type="reset" :disabled="fetching || loading" />
+            <Button type="submit" :disabled="fetching || loading" :loading="'save' === pendingAction" />
+          </Buttons>
+        </footer>
+      </form>
+    </template>
+  </USlideover>
+</template>
+
+<script setup lang="ts">
+import JsonEditorVue from 'json-editor-vue'
+import Alert from '~/components/layout/Alert.vue'
+import Button from '~/components/layout/forms/Button.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+import { useFormSubmit, useMeiliClient, useTask, type DocumentId } from '~/composables'
+import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS, useConfirmationDialog, useToasts } from '~/stores'
+
+type Props = {
+  indexUid: string
+  primaryKey: string
+  documentId: DocumentId
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ saved: []; deleted: [] }>()
+const open = defineModel<boolean>('open', { default: false })
+
+const { t } = useI18n()
+const meili = useMeiliClient()
+const processTask = useTask()
+const { confirm } = useConfirmationDialog()
+const { createToast } = useToasts()
+const { loading, error, handle } = useFormSubmit()
+
+/** Which of the two actions is running, so only its own button spins. */
+const pendingAction = ref<'save' | 'delete' | null>(null)
+const fetching = ref(true)
+/** Last known persisted state, used to reset the editor. Not named `document`: that shadows the global. */
+const savedDocument = ref<any>(null)
+const json = ref('')
+
+/**
+ * `mode="text"` hands back the raw text (`stringified` defaults to `true`), but the built-in mode
+ * switcher lets the user move to tree/table mode, where the binding value becomes parsed JSON.
+ * Normalizing here keeps both cases working — and surfaces malformed JSON as a plain parse error.
+ */
+const parseJson = (value: unknown) => ('string' === typeof value ? JSON.parse(value) : value)
+
+const reset = () => {
+  error.value = null
+  json.value = JSON.stringify(savedDocument.value, null, 2)
+}
+
+const load = async () =>
+  handle(async () => {
+    fetching.value = true
+    try {
+      savedDocument.value = await meili.index(props.indexUid).getDocument(props.documentId)
+      reset()
+    } finally {
+      fetching.value = false
+    }
+  })
+
+// The slideover is kept mounted between openings: (re)load whenever it opens on a document.
+watch([open, () => props.documentId], ([isOpen]) => isOpen && load(), { immediate: true })
+
+const save = () =>
+  handle(async () => {
+    const payload = parseJson(json.value)
+    // `addDocuments` replaces the document matching the primary key. A changed id would silently
+    // create a second document instead of editing this one, so refuse it rather than surprise.
+    if (`${payload?.[props.primaryKey]}` !== `${props.documentId}`) {
+      throw new Error(t('errors.primaryKeyChanged', { primaryKey: props.primaryKey }))
+    }
+    const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: t('toasts.saving') })
+    pendingAction.value = 'save'
+    try {
+      const task = await processTask(() => meili.index(props.indexUid).addDocuments([payload]))
+      if ('succeeded' !== task.status) {
+        // `error` only exists on a resolved Task, not on the enqueued one returned on timeout.
+        throw new Error(('error' in task && task.error?.message) || t('toasts.failed'))
+      }
+      toast.update({ ...TOAST_SUCCESS(t) })
+      savedDocument.value = payload
+      emit('saved')
+    } catch (e) {
+      toast.update({ ...TOAST_FAILURE(t) })
+      throw e
+    } finally {
+      pendingAction.value = null
+    }
+  })
+
+const remove = () =>
+  handle(async () => {
+    if (!(await confirm({ text: t('confirmations.delete', { documentId: props.documentId }) }))) {
+      return
+    }
+    const toast = createToast({ ...TOAST_PLEASEWAIT(t), title: t('toasts.deleting') })
+    pendingAction.value = 'delete'
+    try {
+      const task = await processTask(() => meili.index(props.indexUid).deleteDocument(props.documentId))
+      if ('succeeded' !== task.status) {
+        throw new Error(('error' in task && task.error?.message) || t('toasts.failed'))
+      }
+      toast.update({ ...TOAST_SUCCESS(t) })
+      open.value = false
+      emit('deleted')
+    } catch (e) {
+      toast.update({ ...TOAST_FAILURE(t) })
+      throw e
+    } finally {
+      pendingAction.value = null
+    }
+  })
+</script>
+
+<style scoped>
+/* vanilla-jsoneditor's default accent is blue; tint its chrome with the Meiliweb palette. */
+.json-editor {
+  --jse-theme-color: var(--color-meili-800);
+  --jse-theme-color-highlight: var(--color-meili-700);
+}
+</style>
+
+<i18n>
+en:
+  loading: Loading document...
+  actions:
+    delete: Delete document
+  confirmations:
+    delete: 'Delete document {documentId}? This cannot be undone.'
+  errors:
+    primaryKeyChanged: The primary key ({primaryKey}) cannot be changed. Delete this document and add a new one instead.
+  toasts:
+    saving: Saving document...
+    deleting: Deleting document...
+    failed: Meilisearch could not process this document.
+</i18n>

--- a/app/components/documents/DocumentSlideOver.vue
+++ b/app/components/documents/DocumentSlideOver.vue
@@ -15,7 +15,13 @@
 
         <p v-if="fetching" class="text-sm font-light text-gray-500 italic">{{ t('loading') }}</p>
 
-        <JsonEditorVue v-else v-model="json" mode="text" :read-only="loading" class="json-editor min-h-0 flex-1" />
+        <JsonEditorVue
+          v-else
+          v-model="json"
+          mode="text"
+          :read-only="loading"
+          :onRenderMenu="hideTableMode"
+          class="json-editor min-h-0 flex-1" />
 
         <footer class="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <Button
@@ -68,6 +74,21 @@ const fetching = ref(true)
 /** Last known persisted state, used to reset the editor. Not named `document`: that shadows the global. */
 const savedDocument = ref<any>(null)
 const json = ref('')
+
+/** Subset of vanilla-jsoneditor's `MenuItem` we need; it isn't a direct dependency of ours. */
+type MenuItem = { type: string; text?: string; className?: string }
+
+/**
+ * A Meilisearch document is always a JSON object, and table mode only opens arrays — the button
+ * could never do anything but show "an object cannot be opened in table mode". Drop it, and hand
+ * its `jse-last` class to `tree`, which the menu's CSS uses to close the button group's border.
+ * Matching on the label is what the library gives us; if it ever renames them, the button simply
+ * comes back.
+ */
+const hideTableMode = (items: MenuItem[]) =>
+  items
+    .filter(({ text }) => 'table' !== text)
+    .map((item) => ('tree' === item.text ? { ...item, className: `${item.className ?? ''} jse-last` } : item))
 
 /**
  * `mode="text"` hands back the raw text (`stringified` defaults to `true`), but the built-in mode

--- a/app/components/documents/DocumentsAsTable.vue
+++ b/app/components/documents/DocumentsAsTable.vue
@@ -6,6 +6,9 @@
           <a v-if="looksLikeAPictureUrl(documents[rowIndex][field])" :href="documents[rowIndex][field]" target="_blank">
             <img :src="documents[rowIndex][field]" :alt="documents[rowIndex][field]" class="max-h-48 rounded-lg" />
           </a>
+          <DocumentIdLink v-else-if="field === primaryKey" :document-id="documents[rowIndex][field]">
+            <ValueRenderer :index-uid="indexUid" :field="field" :value="documents[rowIndex][field]" :level="0" />
+          </DocumentIdLink>
           <ValueRenderer v-else :index-uid="indexUid" :field="field" :value="documents[rowIndex][field]" :level="0" />
         </td>
       </template>
@@ -17,11 +20,13 @@
 import { looksLikeAPictureUrl } from '~/utils'
 import Table from '~/components/layout/tables/Table.vue'
 import ValueRenderer from '~/components/documents/ValueRenderer.vue'
+import DocumentIdLink from '~/components/documents/DocumentIdLink.vue'
 
 type Props = {
   documents: Array<any>
   fields: Array<string>
   indexUid: string
+  primaryKey: string
 }
 
 defineProps<Props>()

--- a/app/composables/index.ts
+++ b/app/composables/index.ts
@@ -1,6 +1,7 @@
 export * from './useChatCompletion'
 export * from './useChatWorkspaces'
 export * from './useDateFormatter'
+export * from './useDocumentViewer'
 export * from './useExport'
 export * from './useFields'
 export * from './useFormSubmit'

--- a/app/composables/useDocumentViewer.ts
+++ b/app/composables/useDocumentViewer.ts
@@ -1,0 +1,16 @@
+import type { InjectionKey } from 'vue'
+
+export type DocumentId = string | number
+export type DocumentViewer = (documentId: DocumentId) => void
+
+const DOCUMENT_VIEWER = Symbol('document-viewer') as InjectionKey<DocumentViewer>
+
+/**
+ * The documents page owns the document slideover, but the clickable ids live several levels down
+ * (table cells, cards inside the map view, ...). Provide/inject keeps that plumbing out of the
+ * intermediate components, which don't care about the viewer at all.
+ */
+export const provideDocumentViewer = (openDocument: DocumentViewer) => provide(DOCUMENT_VIEWER, openDocument)
+
+/** Returns `null` where no viewer is provided, so ids simply render as plain values. */
+export const useDocumentViewer = () => inject(DOCUMENT_VIEWER, null)

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -18,6 +18,15 @@
       </template>
     </USlideover>
 
+    <DocumentSlideOver
+      v-if="null !== openedDocumentId"
+      v-model:open="documentSlideOverOpen"
+      :index-uid="index.uid"
+      :primary-key="primaryKey"
+      :document-id="openedDocumentId"
+      @saved="refreshDocuments()"
+      @deleted="refreshDocuments()" />
+
     <template #actions>
       <div
         v-if="tenant.tenantToken"
@@ -124,7 +133,15 @@
 </template>
 
 <script setup lang="ts">
-import { useFields, useIndexLocalSettings, useMeiliClient, useMultiTenancy, usePagination } from '~/composables'
+import {
+  provideDocumentViewer,
+  useFields,
+  useIndexLocalSettings,
+  useMeiliClient,
+  useMultiTenancy,
+  usePagination,
+  type DocumentId,
+} from '~/composables'
 import { getFacetSearchableAttributePatterns, getFilterableAttributePatterns, tryOrThrow } from '~/utils'
 import { NuxtLink } from '#components'
 import FilterPanel from '~/components/documents/FilterPanel.vue'
@@ -255,6 +272,20 @@ const MainComponent = computed(() =>
     ['map', DocumentsAsMap],
   ]),
 )
+
+// Clicking a document id anywhere in the results (table cells, cards) opens the CRUD slideover.
+// It is loaded on demand: it pulls in vanilla-jsoneditor, which weighs more than this page does.
+const DocumentSlideOver = defineAsyncComponent(() => import('~/components/documents/DocumentSlideOver.vue'))
+const openedDocumentId = ref<DocumentId | null>(null)
+const documentSlideOverOpen = ref(false)
+provideDocumentViewer((documentId: DocumentId) => {
+  openedDocumentId.value = documentId
+  documentSlideOverOpen.value = true
+})
+const refreshDocuments = async () => {
+  self.resultset = await searchClient.index(index.uid).search(null, searchParams)
+}
+
 watch(appliedSort, () => (searchParams.offset = 0))
 watch(appliedFilters, () => (searchParams.offset = 0))
 watch(itemsPerPage, () => (searchParams.offset = 0))

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,7 @@ export default defineNuxtConfig({
         '@vueuse/core',
         'file-size', // CJS
         'humanize-string',
+        'json-editor-vue',
         'json-oneline-stringify',
         'jwt-encode', // CJS
         'match-operator',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@vueform/slider": "^2.1.10",
     "@vueuse/core": "^14.3.0",
     "humanize-string": "^3.0.0",
+    "json-editor-vue": "^0.19.1",
     "json-oneline-stringify": "^1.0.0",
     "jwt-encode": "^1.0.1",
     "leaflet": "^1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,6 +553,81 @@
   resolved "https://registry.yarnpkg.com/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz#b6b8eab81f0f9d8378e219dd321df20280e3bbd2"
   integrity sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==
 
+"@codemirror/autocomplete@^6.18.1":
+  version "6.20.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz#696b740312c6a962e14567b49a3661b5924bc5ae"
+  integrity sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.7.1":
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.10.4.tgz#64dec1bd043976eb344e3cc9d15af13b6f724bfd"
+  integrity sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.7.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/lang-json@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.2.tgz#054b160671306667e25d80385286049841836179"
+  integrity sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.10.3":
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.4.tgz#01e70fd5aa3a8a067ff1dfec75d5b6394cdfa058"
+  integrity sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.8.2":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.9.7.tgz#841fc733674389d91fe49a1c34027ad3babdf105"
+  integrity sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.42.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.5.6":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.7.1.tgz#2523a762871d18ad982edc2d4b2fa1da483b0392"
+  integrity sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.37.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.4.1", "@codemirror/state@^6.7.0":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.7.1.tgz#9e88a17448c1dbc7b50acbeeec979ed7ccf1d6fc"
+  integrity sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.34.1", "@codemirror/view@^6.37.0", "@codemirror/view@^6.42.0":
+  version "6.43.8"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.8.tgz#c211dc77aca139ecc51aff7712c0c4a32cc5f74a"
+  integrity sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==
+  dependencies:
+    "@codemirror/state" "^6.7.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
 "@colordx/core@^5.4.3":
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/@colordx/core/-/core-5.4.3.tgz#35a8d239b324a6cdf9a16de9970a32c8abc24824"
@@ -1084,6 +1159,25 @@
     "@floating-ui/utils" "^0.2.11"
     vue-demi ">=0.13.0"
 
+"@fortawesome/fontawesome-common-types@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.1.tgz#913fe0c0aed1184390efeec2546d78f9c4c8dc4a"
+  integrity sha512-k0C0sdHmZtAo6dRDtd1Z/qcpyHbL0CKsjV8seMY/21xGhY5Wsv0XRmiI/xEEH4y2c9b1+jvgNs/3EqhV27yUEA==
+
+"@fortawesome/free-regular-svg-icons@^6.6.0 || ^7.0.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.1.tgz#643bf28ff4a878ee75abbf974a6096bbe3816306"
+  integrity sha512-q1EsmL7Q8DDnkRBUjSvrxbq7c9oVwwVjCn/xa5apKmdp65YSgzUg2y0Ltnd5aDbT6GdAQQdXql5Ha90ArqIReQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.3.1"
+
+"@fortawesome/free-solid-svg-icons@^6.6.0 || ^7.0.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.1.tgz#07d38cd0cffd759ae64c78e40a9a928ecf0cb19a"
+  integrity sha512-v0BLa0eqg7ubvVWeNSHVBs8fWH/GJicERZoJaxJ3FE/lj67VSqzoMg9pzfZVOfLMX10y0pGwQAuxoRVVH2patg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.3.1"
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -1307,7 +1401,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/remapping@^2.3.5":
+"@jridgewell/remapping@^2.3.4", "@jridgewell/remapping@^2.3.5":
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
   integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
@@ -1338,7 +1432,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
-"@jridgewell/sourcemap-codec@^1.5.5":
+"@jridgewell/sourcemap-codec@^1.4.15", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -1359,6 +1453,21 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
+  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
+
+"@jsep-plugin/regex@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
+  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
+
+"@jsonquerylang/jsonquery@^3.1.1 || ^4.0.0 || ^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@jsonquerylang/jsonquery/-/jsonquery-5.1.1.tgz#ebebb913505914591bad1d3b4fe05f6f0377d9c4"
+  integrity sha512-Fj4SoA6Ku09EF+t7OEI8QLipA2A+fJCdEOwnDWG84o5jXMRjkcN5NCMH7kFZb5fP62xz914XV5LBOiDdiUXObg==
+
 "@kwsites/file-exists@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
@@ -1370,6 +1479,34 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
+"@lezer/common@^1.0.0", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.5.2.tgz#d6840db13779e3f1b42e70c9a97c4086d12fae22"
+  integrity sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.2.1":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.3.tgz#e773a012ad0088fbf07ce49cfba875cc9e5bc05f"
+  integrity sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/lr@^1.0.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.10.tgz#b3acc36e5ad049b74ddb7719594e7e74d9161ff5"
+  integrity sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
 
 "@mapbox/node-pre-gyp@^2.0.0":
   version "2.0.0"
@@ -1383,6 +1520,11 @@
     nopt "^8.0.0"
     semver "^7.5.3"
     tar "^7.4.0"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz#bdbe907e00c17c84e33fc51b1519d9aa211e7e8e"
+  integrity sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==
 
 "@miyaneee/rollup-plugin-json5@^1.2.0":
   version "1.2.0"
@@ -2513,6 +2655,11 @@
   resolved "https://registry.yarnpkg.com/@poppinss/exception/-/exception-1.2.3.tgz#b713855e6c9fe2110fea0949455c50828145e64a"
   integrity sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==
 
+"@replit/codemirror-indentation-markers@^6.5.3":
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.3.tgz#1cfe5c557c45dd7f2988cbee278f17607010591b"
+  integrity sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==
+
 "@rolldown/pluginutils@^1.0.0-rc.2", "@rolldown/pluginutils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
@@ -2764,10 +2911,20 @@
   resolved "https://registry.yarnpkg.com/@speed-highlight/core/-/core-1.2.17.tgz#ce4e49dc56a00f675c5e16f0c98a24bb5aec1c57"
   integrity sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==
 
+"@sphinxxxx/color-conversion@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz#03ecc29279e3c0c832f6185a5bfa3497858ac8ca"
+  integrity sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw==
+
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@sveltejs/acorn-typescript@^1.0.10":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz#8c7c3cc7014e212f2e8fccee0159dbecfe602405"
+  integrity sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==
 
 "@swc/helpers@^0.5.0":
   version "0.5.23"
@@ -3172,7 +3329,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
-"@types/estree@1.0.9":
+"@types/estree@1.0.9", "@types/estree@^1.0.5", "@types/estree@^1.0.6":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
   integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
@@ -3201,6 +3358,11 @@
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/web-bluetooth@^0.0.16":
   version "0.0.16"
@@ -3980,6 +4142,16 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.17.1:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -4064,6 +4236,11 @@ aria-hidden@^1.2.4:
   integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
   dependencies:
     tslib "^2.0.0"
+
+aria-query@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.1.tgz#ebcb2c0d7fc43e68e4cb22f774d1209cb627ab42"
+  integrity sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==
 
 array-buffer-byte-length@^1.0.1:
   version "1.0.1"
@@ -4180,6 +4357,11 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axobject-query@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
+  integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
 b4a@^1.6.4:
   version "1.6.6"
@@ -4490,10 +4672,20 @@ cliui@^9.0.1:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 cluster-key-slot@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz#10ccb9ded0729464b6d2e7d714b100a2d1259d43"
   integrity sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==
+
+codemirror-wrapped-line-indent@^1.0.8:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/codemirror-wrapped-line-indent/-/codemirror-wrapped-line-indent-1.0.9.tgz#13cbecdd1a50de1d53a645e38ce9b72f4cc428ed"
+  integrity sha512-oc976hHLt35u6Ojbhub+IWOxEpapZSqYieLEdGhsgFZ4rtYQtdb5KjxzgjCCyVe3t0yk+a6hmaIOEsjU/tZRxQ==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -4634,6 +4826,11 @@ crc32-stream@^6.0.0:
   dependencies:
     crc-32 "^1.2.0"
     readable-stream "^4.0.0"
+
+crelt@^1.0.5, crelt@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.7.tgz#3b441b2ddfa73161d6a2770aa4cd677f895eaf28"
+  integrity sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==
 
 croner@^10.0.1:
   version "10.0.1"
@@ -4918,6 +5115,11 @@ devalue@^5.8.0, devalue@^5.8.1:
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.8.1.tgz#f27290d3a324e2eb20c2714369b01b8ec4de4c61"
   integrity sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==
+
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 diff@^8.0.3:
   version "8.0.4"
@@ -5523,6 +5725,11 @@ eslint@^8.57.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+esm-env@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esm-env/-/esm-env-1.2.2.tgz#263c9455c55861f41618df31b20cb571fc20b75e"
+  integrity sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==
+
 espree@^10.0.1:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.1.0.tgz#8788dae611574c0f070691f522e4116c5a11fc56"
@@ -5552,6 +5759,13 @@ esquery@^1.4.0, esquery@^1.4.2:
   integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
   dependencies:
     estraverse "^5.1.0"
+
+esrap@^2.2.12:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/esrap/-/esrap-2.3.4.tgz#df7cceac18e480da3d09f9e15fe8d3d9ade45abd"
+  integrity sha512-CHnJXZDfBeOAjLIGNy/0BEsmDu5+irHgUXRW9pGptxCbO3uyjJ98crilzFgiBqizW94UodjX3GAPLg/dhEnUfA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 esrecurse@^4.3.0:
   version "4.3.0"
@@ -5675,6 +5889,11 @@ fast-string-width@^3.0.2:
   integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
   dependencies:
     fast-string-truncated-width "^3.0.2"
+
+fast-uri@^3.0.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.2"
@@ -6228,6 +6447,11 @@ image-meta@^0.2.2:
   resolved "https://registry.yarnpkg.com/image-meta/-/image-meta-0.2.2.tgz#a88dbdf1983d7c23a80c3e71d3b8acdb5379f5e0"
   integrity sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==
 
+immutable-json-patch@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/immutable-json-patch/-/immutable-json-patch-6.0.3.tgz#c96f16d87ff3c4d887c8df0c67e4509a0f78f2f2"
+  integrity sha512-qFLRzQLjteiTGy5tRJcYqvuu0r/GdQ1fE27IyNBrJ/k7yGSO0xFr6QX62TtmIqSvjQF3afcNFUHsGPYW7ydaHQ==
+
 immutable@^4.0.0:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
@@ -6451,6 +6675,13 @@ is-reference@1.2.1:
   dependencies:
     "@types/estree" "*"
 
+is-reference@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.3.tgz#9ef7bf9029c70a67b2152da4adf57c23d718910f"
+  integrity sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==
+  dependencies:
+    "@types/estree" "^1.0.6"
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -6560,6 +6791,11 @@ jiti@^2.6.1, jiti@^2.7.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
   integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
 
+jmespath@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6582,6 +6818,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsep@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
+  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -6597,6 +6838,14 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-editor-vue@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/json-editor-vue/-/json-editor-vue-0.19.1.tgz#b2a646b0fb30e2aaa0aabff2bc5940b74a001467"
+  integrity sha512-sLlJXZIWyuESSP6YE3Q3BBZ2HST5Zpl3D5WTe2w1mt9cezi37T1mHQoum3qkj7pKy+P6ERqasIa5Y1Dh+nomPw==
+  dependencies:
+    vanilla-jsoneditor "^3.12.0"
+    vue-demi "^0.14.10"
+
 json-oneline-stringify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-oneline-stringify/-/json-oneline-stringify-1.0.0.tgz#22144126685c0fa8c10abfb7da7ac88c60b70d2b"
@@ -6606,6 +6855,16 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/json-source-map/-/json-source-map-0.6.1.tgz#e0b1f6f4ce13a9ad57e2ae165a24d06e62c79a0f"
+  integrity sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -6633,6 +6892,20 @@ jsonc-eslint-parser@^2.3.0:
     eslint-visitor-keys "^3.0.0"
     espree "^9.0.0"
     semver "^7.3.5"
+
+jsonpath-plus@^10.3.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz#73cf545c231afda21452150b7a2a58e48e109702"
+  integrity sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==
+  dependencies:
+    "@jsep-plugin/assignment" "^1.3.0"
+    "@jsep-plugin/regex" "^1.0.4"
+    jsep "^1.4.0"
+
+jsonrepair@^3.0.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/jsonrepair/-/jsonrepair-3.15.0.tgz#03b4c15f313f0a6e6a1ccb66b6deeeb859e6f0c8"
+  integrity sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==
 
 jwt-encode@^1.0.1:
   version "1.0.1"
@@ -6826,12 +7099,22 @@ local-pkg@^1.1.2, local-pkg@^1.2.0, local-pkg@^1.2.1:
     pkg-types "^2.3.0"
     quansync "^0.2.11"
 
+locate-character@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
+  integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.23:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -6942,6 +7225,11 @@ meilisearch@^0.60.0:
   version "0.60.0"
   resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.60.0.tgz#53b9f9741f66f3337121f809423d28af341f0bbe"
   integrity sha512-z32KgxE6/7hRzbVfzUgzlmNl2OS7TwGE6wSWs2tVEuAY9DWrX6zAmt0s7wTyelH36orIaZ3/t1mQsCsExGtVDQ==
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -7181,6 +7469,11 @@ napi-wasm@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/napi-wasm/-/napi-wasm-1.1.0.tgz#bbe617823765ae9c1bc12ff5942370eae7b2ba4e"
   integrity sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -8455,6 +8748,11 @@ reka-ui@^2.0.0:
     defu "^6.1.5"
     ohash "^2.0.11"
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -8982,6 +9280,11 @@ structured-clone-es@^2.0.0:
   resolved "https://registry.yarnpkg.com/structured-clone-es/-/structured-clone-es-2.0.0.tgz#ab53cf4e2934c7b5fb17bda9761ac5e809d1b9cd"
   integrity sha512-5UuAHmBLXYPCl22xWJrFuGmIhBKQzxISPVz6E7nmTmTcAOpUzlbjKJsRrCE4vADmMQ0dzeCnlWn9XufnAGf76Q==
 
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
 stylehacks@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-8.0.1.tgz#01b545dafaecdf871854dd74f9e001ff2d9233d4"
@@ -9020,6 +9323,28 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+svelte@^5.0.0:
+  version "5.56.9"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.56.9.tgz#ef93c629051f4848d91bae86693a186b66576fd3"
+  integrity sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.4"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@sveltejs/acorn-typescript" "^1.0.10"
+    "@types/estree" "^1.0.5"
+    "@types/trusted-types" "^2.0.7"
+    acorn "^8.12.1"
+    aria-query "5.3.1"
+    axobject-query "^4.1.0"
+    clsx "^2.1.1"
+    devalue "^5.8.1"
+    esm-env "^1.2.1"
+    esrap "^2.2.12"
+    is-reference "^3.0.3"
+    locate-character "^3.0.0"
+    magic-string "^0.30.11"
+    zimmerframe "^1.1.2"
 
 svgo@^4.0.1:
   version "4.0.1"
@@ -9632,6 +9957,45 @@ v3-infinite-loading@^1.3.2:
   resolved "https://registry.yarnpkg.com/v3-infinite-loading/-/v3-infinite-loading-1.3.2.tgz#c95c8031ac648997b667bb580dba5f0301fb3597"
   integrity sha512-2Bg8X8nqd9tKEOJdITABtuX2BMSYo/t+eZOAD+9/xz0fGyGDclglmWjo9Zs4dr/T63liO7EniBAunBesM2QhBA==
 
+vanilla-jsoneditor@^3.12.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/vanilla-jsoneditor/-/vanilla-jsoneditor-3.13.0.tgz#a66985d247a73705c47b1d6a7220063b6613549b"
+  integrity sha512-u9C+D8Ocgr39Gnsfu7USjilfKssqbDqZehMdE0qbwIFnZFdNwkU4iKeEvJxvYbmlVi/sMLxMTrU14PhtXVyiZg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.18.1"
+    "@codemirror/commands" "^6.7.1"
+    "@codemirror/lang-json" "^6.0.1"
+    "@codemirror/language" "^6.10.3"
+    "@codemirror/lint" "^6.8.2"
+    "@codemirror/search" "^6.5.6"
+    "@codemirror/state" "^6.4.1"
+    "@codemirror/view" "^6.34.1"
+    "@fortawesome/free-regular-svg-icons" "^6.6.0 || ^7.0.1"
+    "@fortawesome/free-solid-svg-icons" "^6.6.0 || ^7.0.1"
+    "@jsonquerylang/jsonquery" "^3.1.1 || ^4.0.0 || ^5.0.0"
+    "@lezer/highlight" "^1.2.1"
+    "@replit/codemirror-indentation-markers" "^6.5.3"
+    ajv "^8.17.1"
+    codemirror-wrapped-line-indent "^1.0.8"
+    diff-sequences "^29.6.3"
+    immutable-json-patch "^6.0.1"
+    jmespath "^0.16.0"
+    json-source-map "^0.6.1"
+    jsonpath-plus "^10.3.0"
+    jsonrepair "^3.0.0"
+    lodash-es "^4.17.23"
+    memoize-one "^6.0.0"
+    natural-compare-lite "^1.4.0"
+    svelte "^5.0.0"
+    vanilla-picker "^2.12.3"
+
+vanilla-picker@^2.12.3:
+  version "2.12.3"
+  resolved "https://registry.yarnpkg.com/vanilla-picker/-/vanilla-picker-2.12.3.tgz#1cc47b641a2b9c9afc5ac3a9a02febace0f1b17a"
+  integrity sha512-qVkT1E7yMbUsB2mmJNFmaXMWE2hF8ffqzMMwe9zdAikd8u2VfnsVY2HQcOUi2F38bgbxzlJBEdS1UUhOXdF9GQ==
+  dependencies:
+    "@sphinxxxx/color-conversion" "^2.2.2"
+
 vaul-vue@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/vaul-vue/-/vaul-vue-0.4.1.tgz#76ad8ccf8f9a61ea89ae51874defd3e36a5cef6d"
@@ -9730,7 +10094,7 @@ vue-component-type-helpers@^3.3.5:
   resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-3.3.7.tgz#98f2a53901c3883a674bbc063f74c51a97eb7057"
   integrity sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==
 
-vue-demi@*, vue-demi@>=0.13.0, vue-demi@>=0.14.8:
+vue-demi@*, vue-demi@>=0.13.0, vue-demi@>=0.14.8, vue-demi@^0.14.10:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
   integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
@@ -9850,7 +10214,7 @@ vue@^3.5.35, vue@~3.5.34:
     "@vue/server-renderer" "3.5.38"
     "@vue/shared" "3.5.38"
 
-w3c-keyname@^2.2.0:
+w3c-keyname@^2.2.0, w3c-keyname@^2.2.4:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
   integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
@@ -10058,6 +10422,11 @@ youch@^4.1.1:
     "@speed-highlight/core" "^1.2.14"
     cookie-es "^3.0.1"
     youch-core "^0.3.3"
+
+zimmerframe@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/zimmerframe/-/zimmerframe-1.1.4.tgz#0352b5cafad3ad4526b0a526a9a52d9c040d865b"
+  integrity sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==
 
 zip-stream@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
## What

Clicking a document id in the search results — in the table view or the cards view — opens a wide slideover where the document can be **viewed, edited as JSON, and deleted**.

The editor is [`json-editor-vue`](https://npmx.dev/package/json-editor-vue) (text / tree / table modes, syntax highlighting, inline JSON validation), tinted with the Meiliweb palette.

## How

- **Fresh read.** The document is refetched with `getDocument` rather than reused from the search hit, which can be partial (`attributesToRetrieve`) and carries `_rankingScore` / `_rankingScoreDetails` metadata.
- **Replace, not merge.** Saving uses `addDocuments`, so removing a key in the editor actually removes it from the document.
- **Primary key is locked.** Changing it would silently create a *second* document instead of editing this one, so it is refused with an explicit message.
- **Tasks are awaited.** Both save and delete go through `useTask`, and the form stays disabled until the Meilisearch task resolves — the refreshed list always reflects the outcome. Deletion goes through the existing confirmation dialog.
- **Admin client.** CRUD uses `useMeiliClient()`, not the tenant-token client used for the search preview.
- **Plumbing.** A tiny `provideDocumentViewer` / `useDocumentViewer` pair carries the open callback from the page down to the id cells and cards, instead of threading emits through three intermediate components.
- **Bundle.** The slideover is `defineAsyncComponent`-ed: `vanilla-jsoneditor` lands in its own ~1 MB chunk instead of the documents page chunk.

## Verified manually

Against a local Meilisearch 1.53.1 seeded with the `books` dataset:

- open from the cards view and from the table view — loads the right document ✅
- edit a value in text mode → saved, list refreshed, confirmed via the REST API ✅
- save from tree mode → value types preserved ✅
- change the primary key → rejected with a clear error, nothing sent ✅
- invalid JSON → `SyntaxError` surfaced in the alert, nothing sent ✅
- delete → confirmation dialog, task awaited, slideover closed, list refreshed ✅
- `yarn lint`, `yarn run check` and `yarn build` pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)