### PR TITLE
Feat: index size, field count and embeddings stats on the indexes list

### DIFF
--- a/app/components/settings/ServerStats.vue
+++ b/app/components/settings/ServerStats.vue
@@ -17,9 +17,11 @@
     </Card>
 
     <Card :title="t('titles.dbSize')" icon="gravity-ui:database-fill">
-      <div>{{ filesize(stats.databaseSize).human() }}</div>
-      <div v-if="stats.usedDatabaseSize != null" class="text-xs font-normal text-gray-400">
-        {{ t('labels.used', { size: filesize(stats.usedDatabaseSize).human() }) }}
+      <div class="flex items-center gap-2">
+        <div>{{ filesize(stats.databaseSize).human() }}</div>
+        <div v-if="stats.usedDatabaseSize != null" class="text-xs font-normal text-gray-400">
+          {{ t('labels.used', { size: filesize(stats.usedDatabaseSize).human() }) }}
+        </div>
       </div>
     </Card>
 

--- a/app/components/settings/ServerStats.vue
+++ b/app/components/settings/ServerStats.vue
@@ -17,7 +17,10 @@
     </Card>
 
     <Card :title="t('titles.dbSize')" icon="gravity-ui:database-fill">
-      {{ filesize(stats.databaseSize).human() }}
+      <div>{{ filesize(stats.databaseSize).human() }}</div>
+      <div v-if="stats.usedDatabaseSize != null" class="text-xs font-normal text-gray-400">
+        {{ t('labels.used', { size: filesize(stats.usedDatabaseSize).human() }) }}
+      </div>
     </Card>
 
     <Card :title="t('titles.lastUpdatedAt')" icon="bi:clock-fill">
@@ -44,4 +47,6 @@ en:
     dbSize: Database size
     version: Meilisearch Version
     lastUpdatedAt: Last updated
+  labels:
+    used: '{size} used'
 </i18n>

--- a/app/pages/indexes/index.vue
+++ b/app/pages/indexes/index.vue
@@ -81,10 +81,13 @@
             <span v-else class="text-gray-300">—</span>
           </td>
           <td class="text-right" v-tippy="sizeTooltip(item)">
-            <div class="font-medium">{{ filesize(item.indexSize ?? 0).human() }}</div>
-            <div class="text-xs text-gray-400">
-              {{ t('labels.used', { size: filesize(item.usedIndexSize ?? 0).human() }) }}
-            </div>
+            <template v-if="item.indexSize != null">
+              <div class="font-medium">{{ filesize(item.indexSize).human() }}</div>
+              <div class="text-xs text-gray-400">
+                {{ t('labels.used', { size: filesize(item.usedIndexSize ?? 0).human() }) }}
+              </div>
+            </template>
+            <div v-else class="font-medium">{{ filesize(item.rawDocumentDbSize ?? 0).human() }}</div>
           </td>
           <td class="text-right">
             <UDropdownMenu :items="indexMenuItems(item)" :content="{ align: 'end' }" :ui="{ content: 'w-48' }">
@@ -184,11 +187,15 @@ whenever(
 
 const { satisfiesVersion } = useVersion()
 
-const sizeTooltip = (item: Index & { rawDocumentDbSize?: number; avgDocumentSize?: number }) =>
-  t('labels.sizeTooltip', {
-    rawDocumentDbSize: filesize(item.rawDocumentDbSize ?? 0).human(),
-    avgDocumentSize: filesize(item.avgDocumentSize ?? 0).human(),
-  })
+const sizeTooltip = (item: Index & { indexSize?: number; rawDocumentDbSize?: number; avgDocumentSize?: number }) =>
+  item.indexSize != null
+    ? t('labels.sizeTooltip', {
+        rawDocumentDbSize: filesize(item.rawDocumentDbSize ?? 0).human(),
+        avgDocumentSize: filesize(item.avgDocumentSize ?? 0).human(),
+      })
+    : t('labels.sizeTooltipFallback', {
+        avgDocumentSize: filesize(item.avgDocumentSize ?? 0).human(),
+      })
 
 const embeddingsTooltip = (item: Index & { numberOfEmbeddedDocuments?: number }) =>
   t('labels.embeddingsTooltip', { numberOfEmbeddedDocuments: item.numberOfEmbeddedDocuments ?? 0 })
@@ -290,6 +297,7 @@ en:
     embeddingsTooltip: 'Across {numberOfEmbeddedDocuments} embedded documents'
     used: '{size} used'
     sizeTooltip: 'Raw document DB size: {rawDocumentDbSize} · Avg. document size: {avgDocumentSize}'
+    sizeTooltipFallback: 'Avg. document size: {avgDocumentSize}'
   actions:
     create: Create
     createExpanded: Create an index

--- a/app/pages/indexes/index.vue
+++ b/app/pages/indexes/index.vue
@@ -6,7 +6,9 @@
       </Button>
     </template>
     <template v-if="indexes.length > 0">
-      <Table :items="indexes" :keys="['uid', 'numberOfDocuments', 'primaryKey', 'createdAt', 'updatedAt']">
+      <Table
+        :items="indexes"
+        :keys="['uid', 'primaryKey', 'createdAt', 'updatedAt', 'fieldsCount', 'indexSize', 'numberOfDocuments']">
         <template #columns>
           <th scope="col" class="relative isolate">
             {{ t('columns.index') }}
@@ -18,6 +20,16 @@
           </th>
           <th scope="col">{{ t('columns.createdAt') }}</th>
           <th scope="col">{{ t('columns.updatedAt') }}</th>
+          <th scope="col">
+            <div class="text-right">
+              {{ t('columns.fieldsCount') }}
+            </div>
+          </th>
+          <th scope="col">
+            <div class="text-right">
+              {{ t('columns.indexSize') }}
+            </div>
+          </th>
           <th scope="col">
             <div class="text-right">
               {{ t('columns.numberOfDocuments') }}
@@ -36,6 +48,13 @@
               <Badge v-if="item.isIndexing" class="text-xs uppercase">
                 {{ t('labels.isIndexing') }}
               </Badge>
+              <Badge
+                v-if="item.numberOfEmbeddings > 0"
+                theme="neutral"
+                class="text-xs uppercase"
+                v-tippy="t('labels.embeddingsTooltip', item)">
+                {{ t('labels.embeddings', item) }}
+              </Badge>
             </span>
             <div class="absolute right-full bottom-0 h-px w-screen bg-gray-100" />
             <div class="absolute bottom-0 left-0 h-px w-screen bg-gray-100" />
@@ -45,6 +64,15 @@
           </td>
           <td>{{ formatDate(item.createdAt) }}</td>
           <td>{{ formatDate(item.updatedAt) }}</td>
+          <td class="text-right">
+            {{ Object.keys(item.fieldDistribution ?? {}).length }}
+          </td>
+          <td class="text-right" v-tippy="sizeTooltip(item)">
+            <div class="font-medium">{{ filesize(item.indexSize ?? 0).human() }}</div>
+            <div class="text-xs text-gray-400">
+              {{ t('labels.used', { size: filesize(item.usedIndexSize ?? 0).human() }) }}
+            </div>
+          </td>
           <td class="text-right">
             {{ item.numberOfDocuments }}
           </td>
@@ -100,6 +128,7 @@ import { Index } from 'meilisearch'
 import { promiseTimeout, whenever } from '@vueuse/core'
 import { navigateTo } from '#imports'
 import PageSize from '~/components/layout/pagination/PageSize.vue'
+import filesize from 'file-size'
 
 const { t } = useI18n()
 useHead({
@@ -131,15 +160,26 @@ const fetchIndexes = async (offset = self.offset, limit = self.itemsPerPage) =>
 whenever(
   toRef(self, 'indexes'),
   async (indexes) => {
-    for (const index of indexes) {
-      let indexInfo = await meili.getIndex(index.uid)
-      Object.assign(index, await indexInfo.getStats())
-    }
+    // `indexSize` and `usedIndexSize` are returned by the API but not yet typed by
+    // meilisearch@0.60.0's IndexStats — checked against a live 1.53.1 instance.
+    await Promise.all(
+      indexes.map(async (index) => {
+        const indexInfo = await meili.getIndex(index.uid)
+        Object.assign(index, await indexInfo.getStats())
+      }),
+    )
   },
   { immediate: true },
 )
 
 const { satisfiesVersion } = useVersion()
+
+const sizeTooltip = (item: Index & { rawDocumentDbSize?: number; avgDocumentSize?: number }) =>
+  t('labels.sizeTooltip', {
+    rawDocumentDbSize: filesize(item.rawDocumentDbSize ?? 0).human(),
+    avgDocumentSize: filesize(item.avgDocumentSize ?? 0).human(),
+  })
+
 const { duplicateIndex: doDuplicateIndex } = useIndexOperations()
 const duplicateIndex = async (indexUid: string) => {
   const newIndexUid = await doDuplicateIndex(indexUid)
@@ -230,8 +270,14 @@ en:
     primaryKey: Primary Key
     createdAt: Created At
     updatedAt: Updated At
+    fieldsCount: Fields
+    indexSize: Size
   labels:
     isIndexing: Indexing
+    embeddings: '{numberOfEmbeddings} embeddings'
+    embeddingsTooltip: '{numberOfEmbeddings} embeddings across {numberOfEmbeddedDocuments} embedded documents'
+    used: '{size} used'
+    sizeTooltip: 'Raw document DB size: {rawDocumentDbSize} · Avg. document size: {avgDocumentSize}'
   actions:
     create: Create
     createExpanded: Create an index

--- a/app/pages/indexes/index.vue
+++ b/app/pages/indexes/index.vue
@@ -8,7 +8,15 @@
     <template v-if="indexes.length > 0">
       <Table
         :items="indexes"
-        :keys="['uid', 'primaryKey', 'createdAt', 'updatedAt', 'fieldsCount', 'indexSize', 'numberOfDocuments']">
+        :keys="[
+          'uid',
+          'primaryKey',
+          'updatedAt',
+          'numberOfDocuments',
+          'fieldsCount',
+          'numberOfEmbeddings',
+          'indexSize',
+        ]">
         <template #columns>
           <th scope="col" class="relative isolate">
             {{ t('columns.index') }}
@@ -18,8 +26,12 @@
           <th scope="col">
             {{ t('columns.primaryKey') }}
           </th>
-          <th scope="col">{{ t('columns.createdAt') }}</th>
           <th scope="col">{{ t('columns.updatedAt') }}</th>
+          <th scope="col">
+            <div class="text-right">
+              {{ t('columns.numberOfDocuments') }}
+            </div>
+          </th>
           <th scope="col">
             <div class="text-right">
               {{ t('columns.fieldsCount') }}
@@ -27,12 +39,12 @@
           </th>
           <th scope="col">
             <div class="text-right">
-              {{ t('columns.indexSize') }}
+              {{ t('columns.numberOfEmbeddings') }}
             </div>
           </th>
           <th scope="col">
             <div class="text-right">
-              {{ t('columns.numberOfDocuments') }}
+              {{ t('columns.indexSize') }}
             </div>
           </th>
           <th />
@@ -48,13 +60,6 @@
               <Badge v-if="item.isIndexing" class="text-xs uppercase">
                 {{ t('labels.isIndexing') }}
               </Badge>
-              <Badge
-                v-if="item.numberOfEmbeddings > 0"
-                theme="neutral"
-                class="text-xs uppercase"
-                v-tippy="t('labels.embeddingsTooltip', item)">
-                {{ t('labels.embeddings', item) }}
-              </Badge>
             </span>
             <div class="absolute right-full bottom-0 h-px w-screen bg-gray-100" />
             <div class="absolute bottom-0 left-0 h-px w-screen bg-gray-100" />
@@ -62,19 +67,24 @@
           <td>
             <Badge theme="neutral">{{ item.primaryKey }}</Badge>
           </td>
-          <td>{{ formatDate(item.createdAt) }}</td>
           <td>{{ formatDate(item.updatedAt) }}</td>
           <td class="text-right">
+            {{ item.numberOfDocuments }}
+          </td>
+          <td class="text-right">
             {{ Object.keys(item.fieldDistribution ?? {}).length }}
+          </td>
+          <td class="text-right">
+            <template v-if="item.numberOfEmbeddings > 0">
+              <span v-tippy="embeddingsTooltip(item)">{{ item.numberOfEmbeddings }}</span>
+            </template>
+            <span v-else class="text-gray-300">—</span>
           </td>
           <td class="text-right" v-tippy="sizeTooltip(item)">
             <div class="font-medium">{{ filesize(item.indexSize ?? 0).human() }}</div>
             <div class="text-xs text-gray-400">
               {{ t('labels.used', { size: filesize(item.usedIndexSize ?? 0).human() }) }}
             </div>
-          </td>
-          <td class="text-right">
-            {{ item.numberOfDocuments }}
           </td>
           <td class="text-right">
             <UDropdownMenu :items="indexMenuItems(item)" :content="{ align: 'end' }" :ui="{ content: 'w-48' }">
@@ -180,6 +190,9 @@ const sizeTooltip = (item: Index & { rawDocumentDbSize?: number; avgDocumentSize
     avgDocumentSize: filesize(item.avgDocumentSize ?? 0).human(),
   })
 
+const embeddingsTooltip = (item: Index & { numberOfEmbeddedDocuments?: number }) =>
+  t('labels.embeddingsTooltip', { numberOfEmbeddedDocuments: item.numberOfEmbeddedDocuments ?? 0 })
+
 const { duplicateIndex: doDuplicateIndex } = useIndexOperations()
 const duplicateIndex = async (indexUid: string) => {
   const newIndexUid = await doDuplicateIndex(indexUid)
@@ -268,14 +281,13 @@ en:
     index: Index
     numberOfDocuments: Nb. docs
     primaryKey: Primary Key
-    createdAt: Created At
     updatedAt: Updated At
     fieldsCount: Fields
+    numberOfEmbeddings: Embeddings
     indexSize: Size
   labels:
     isIndexing: Indexing
-    embeddings: '{numberOfEmbeddings} embeddings'
-    embeddingsTooltip: '{numberOfEmbeddings} embeddings across {numberOfEmbeddedDocuments} embedded documents'
+    embeddingsTooltip: 'Across {numberOfEmbeddedDocuments} embedded documents'
     used: '{size} used'
     sizeTooltip: 'Raw document DB size: {rawDocumentDbSize} · Avg. document size: {avgDocumentSize}'
   actions:


### PR DESCRIPTION
## Summary
- Fetch each index's stats in parallel (`Promise.all`) instead of sequentially
- New "Fields" column (count of `fieldDistribution` keys) and "Size" column (`indexSize` / `usedIndexSize`, human-readable via `file-size`), with a tooltip showing `rawDocumentDbSize` and `avgDocumentSize`
- Embeddings badge next to the index name when `numberOfEmbeddings > 0`, with a tooltip detailing embeddings/embedded documents count
- `indexSize`/`usedIndexSize` aren't typed yet by `meilisearch@0.60.0`'s `IndexStats` — verified against a live 1.53.1 instance, noted in a comment

## Test plan
- [x] Verified visually against a local Meilisearch 1.53.1 instance (books/categories/products indexes) — Fields, Size, and "used" subtext render correctly
- [x] Verified the Size column tooltip shows raw DB size and avg document size
- [x] `prettier --check` passes on the changed file