### PR TITLE
Move Export into a Backup tab

### DIFF
--- a/app/components/layout/TopNavigation.vue
+++ b/app/components/layout/TopNavigation.vue
@@ -138,7 +138,6 @@ import type { DropdownMenuItem } from '@nuxt/ui'
 import { computed, reactive, ref, toRefs } from 'vue'
 import GithubButton from '~/components/layout/GithubButton.vue'
 import LogoutButton from '~/components/layout/LogoutButton.vue'
-import { EXPORT_MIN_VERSION } from '~/composables'
 import { useChatAvailability, useCredentials, useVersion } from '~/stores'
 
 const route = useRoute()
@@ -186,12 +185,6 @@ const navigation = reactive([
     visible: computed(() => chatAvailable.value),
   },
   {
-    name: 'Export',
-    href: '/export',
-    current: computed(() => route.name?.startsWith('export')),
-    visible: computed(() => satisfiesVersion(EXPORT_MIN_VERSION)),
-  },
-  {
     name: 'Experimental',
     href: '/experimental-features',
     current: computed(() => route.name?.startsWith('experimental-features')),
@@ -203,7 +196,7 @@ const visibleNavigation = computed(() => navigation.filter((item) => item.visibl
 
 const { credentials, records, switchInstance, removeInstance: doRemoveInstance } = safeToRefs(useCredentials())
 const { confirm } = useConfirmationDialog()
-const { version, satisfiesVersion } = useVersion()
+const { version } = useVersion()
 const mobileMenuOpen = ref(false)
 const self: any = reactive({
   records,

--- a/app/pages/backup/dumps.vue
+++ b/app/pages/backup/dumps.vue
@@ -27,7 +27,8 @@
 <script setup lang="ts">
 import { tryOrThrow, useMeiliClient, useToasts } from '#imports'
 import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS } from '~/stores/toasts'
-import { useFormSubmit, useTask } from '~/composables'
+import { EXPORT_MIN_VERSION, useFormSubmit, useTask } from '~/composables'
+import { useVersion } from '~/stores'
 import Alert from '~/components/layout/Alert.vue'
 import PageTabs from '~/components/layout/PageTabs.vue'
 import BackupTasksTable from '~/components/backup/BackupTasksTable.vue'
@@ -36,6 +37,7 @@ import Button from '~/components/layout/forms/Button.vue'
 
 const { t } = useI18n()
 const meili = useMeiliClient()
+const { satisfiesVersion } = useVersion()
 const fetchTasks = () => tryOrThrow(() => meili.tasks.getTasks({ types: ['dumpCreation'] }))
 const { createToast } = useToasts()
 const processTask = useTask()
@@ -45,10 +47,11 @@ const { loading, error, handle } = useFormSubmit({
     text: t('confirmations.create.text'),
   },
 })
-const tabs = [
+const tabs = computed(() => [
   { label: t('tabs.dumps'), to: '/backup/dumps' },
   { label: t('tabs.snapshots'), to: '/backup/snapshots' },
-]
+  ...(satisfiesVersion(EXPORT_MIN_VERSION) ? [{ label: t('tabs.export'), to: '/backup/export' }] : []),
+])
 const self = reactive({
   tasks: await fetchTasks(),
 })
@@ -93,6 +96,7 @@ en:
   tabs:
     dumps: Dumps
     snapshots: Snapshots
+    export: Export
   columns:
     dumpUid: Dump Uid
   emptyState: No dumps yet.

--- a/app/pages/backup/export.vue
+++ b/app/pages/backup/export.vue
@@ -1,5 +1,7 @@
 <template>
-  <Layout :title="t('title')" :subtitle="t('subtitle')">
+  <Layout :title="t('title')">
+    <PageTabs :items="tabs" />
+
     <Alert v-if="!satisfiesVersion(EXPORT_MIN_VERSION)" theme="warning" :title="t('unavailable.title')">
       {{ t('unavailable.text') }}
     </Alert>
@@ -9,6 +11,7 @@
 
 <script setup lang="ts">
 import Alert from '~/components/layout/Alert.vue'
+import PageTabs from '~/components/layout/PageTabs.vue'
 import ExportForm from '~/components/export/ExportForm.vue'
 import { EXPORT_MIN_VERSION } from '~/composables'
 import { useVersion } from '~/stores'
@@ -16,13 +19,23 @@ import { useVersion } from '~/stores'
 const { t } = useI18n()
 const { satisfiesVersion } = useVersion()
 
-useHead({ title: t('title') })
+const tabs = [
+  { label: t('tabs.dumps'), to: '/backup/dumps' },
+  { label: t('tabs.snapshots'), to: '/backup/snapshots' },
+  { label: t('tabs.export'), to: '/backup/export' },
+]
+
+useHead({ title: t('pageTitle') })
 </script>
 
 <i18n>
 en:
-  title: Export
-  subtitle: Export all or part of this instance to another Meilisearch instance.
+  title: Backup
+  pageTitle: Export
+  tabs:
+    dumps: Dumps
+    snapshots: Snapshots
+    export: Export
   unavailable:
     title: Export unavailable
     text: Exporting to a remote instance requires Meilisearch 1.16 or later.

--- a/app/pages/backup/snapshots.vue
+++ b/app/pages/backup/snapshots.vue
@@ -27,7 +27,8 @@
 <script setup lang="ts">
 import { tryOrThrow, useMeiliClient, useToasts } from '#imports'
 import { TOAST_FAILURE, TOAST_PLEASEWAIT, TOAST_SUCCESS } from '~/stores/toasts'
-import { useFormSubmit, useTask } from '~/composables'
+import { EXPORT_MIN_VERSION, useFormSubmit, useTask } from '~/composables'
+import { useVersion } from '~/stores'
 import Alert from '~/components/layout/Alert.vue'
 import PageTabs from '~/components/layout/PageTabs.vue'
 import BackupTasksTable from '~/components/backup/BackupTasksTable.vue'
@@ -36,6 +37,7 @@ import Button from '~/components/layout/forms/Button.vue'
 
 const { t } = useI18n()
 const meili = useMeiliClient()
+const { satisfiesVersion } = useVersion()
 const fetchTasks = () => tryOrThrow(() => meili.tasks.getTasks({ types: ['snapshotCreation'] }))
 const { createToast } = useToasts()
 const processTask = useTask()
@@ -45,10 +47,11 @@ const { loading, error, handle } = useFormSubmit({
     text: t('confirmations.create.text'),
   },
 })
-const tabs = [
+const tabs = computed(() => [
   { label: t('tabs.dumps'), to: '/backup/dumps' },
   { label: t('tabs.snapshots'), to: '/backup/snapshots' },
-]
+  ...(satisfiesVersion(EXPORT_MIN_VERSION) ? [{ label: t('tabs.export'), to: '/backup/export' }] : []),
+])
 const self = reactive({
   tasks: await fetchTasks(),
 })
@@ -93,6 +96,7 @@ en:
   tabs:
     dumps: Dumps
     snapshots: Snapshots
+    export: Export
   emptyState: No snapshots yet.
   actions:
     create: Create snapshot


### PR DESCRIPTION
## Summary
- "Export" (added in #79) was still a standalone entry in the top menu. It now lives at `/backup/export`, as a third tab alongside Dumps and Snapshots, consistent with the rest of the Backup section.
- Removed the top-level `/export` route and its nav entry.
- The Export tab is only shown once `satisfiesVersion(EXPORT_MIN_VERSION)` resolves true (Meilisearch >= 1.16), same gating as before — now reactive via `computed` since the version check resolves asynchronously.

## Test plan
- [x] `yarn lint` / `yarn run check` pass
- [x] `yarn build` succeeds
- [x] Manually verified in browser against a local Meilisearch instance: Backup > Dumps/Snapshots/Export tabs all render and navigate correctly, top menu no longer shows "Export"

🤖 Generated with [Claude Code](https://claude.com/claude-code)