### PR TITLE
Fix stale local settings & add illustration attribute override

### DIFF
--- a/app/components/documents/DocumentCard.vue
+++ b/app/components/documents/DocumentCard.vue
@@ -53,7 +53,7 @@
 import HighlightedText from './HighlightedText.vue'
 import ValueRenderer from './ValueRenderer.vue'
 import DocumentIdLink from './DocumentIdLink.vue'
-import { useFields } from '~/composables'
+import { useFields, useIndexLocalSettings } from '~/composables'
 import { looksLikeAPictureUrl } from '~/utils'
 
 type Props = {
@@ -64,7 +64,12 @@ type Props = {
 
 const props = defineProps<Props>()
 
-const picture = computed(() => Object.values(props.document).find(looksLikeAPictureUrl) as string | null)
+const { illustrationAttribute } = useIndexLocalSettings(props.indexUid)
+const picture = computed(() =>
+  illustrationAttribute.value
+    ? props.document[illustrationAttribute.value] ?? null
+    : (Object.values(props.document).find(looksLikeAPictureUrl) as string | null),
+)
 
 const { fieldsWithoutPrimaryKey, nameField } = useFields(
   props.primaryKey,

--- a/app/components/documents/DocumentCard.vue
+++ b/app/components/documents/DocumentCard.vue
@@ -74,6 +74,7 @@ const picture = computed(() =>
 const { fieldsWithoutPrimaryKey, nameField } = useFields(
   props.primaryKey,
   computed(() => Object.keys(props.document)),
+  props.indexUid,
 )
 const self: any = reactive({
   nameField,

--- a/app/components/documents/DocumentsAsMap.vue
+++ b/app/components/documents/DocumentsAsMap.vue
@@ -61,7 +61,7 @@ type ZoomEndEvent = {
 }
 
 const props = defineProps<Props>()
-const { nameField } = useFields(props.primaryKey, props.fields)
+const { nameField } = useFields(props.primaryKey, props.fields, props.indexUid)
 const center = ref([0, 0])
 const scrollToDocument = (doc: any) => {
   document.getElementById(`document-${doc[props.primaryKey]}`)?.scrollIntoView({ behavior: 'smooth' })

--- a/app/components/settings/AttributesAsIllustrationEditor.vue
+++ b/app/components/settings/AttributesAsIllustrationEditor.vue
@@ -1,0 +1,63 @@
+<template>
+  <form class="space-y-4" @reset.prevent="reset()" @submit.prevent="submit()">
+    <UFormField :label="t('labels.illustrationAttribute')" :help="t('help.illustrationAttribute')">
+      <USelect v-model="editableAttribute" :items="attributeItems" class="w-full sm:w-80" />
+    </UFormField>
+    <footer class="flex flex-col items-center justify-end sm:flex-row">
+      <Buttons>
+        <Button type="reset" :disabled="!modified" />
+        <Button type="submit" :disabled="!modified" />
+      </Buttons>
+    </footer>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { useIndexLocalSettings } from '~/composables'
+import { resettableRef } from '~/utils'
+import Button from '~/components/layout/forms/Button.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+
+type Props = {
+  indexUid: string
+  fields: Array<string>
+}
+const props = defineProps<Props>()
+const { t } = useI18n()
+const localSettings = reactive(useIndexLocalSettings(props.indexUid))
+
+// `USelect` reserves the empty string for "no selection", so auto-detect needs its own sentinel.
+const AUTO_DETECT = '__auto__'
+
+// A previously chosen attribute may no longer exist on this index's documents (removed, renamed) —
+// silently fall back to auto-detect rather than keep pointing at a field that isn't there anymore.
+if (localSettings.illustrationAttribute && !props.fields.includes(localSettings.illustrationAttribute)) {
+  localSettings.illustrationAttribute = null
+}
+
+const attributeItems = computed(() => [
+  { label: t('labels.autoDetect'), value: AUTO_DETECT },
+  ...props.fields.map((field) => ({ label: field, value: field })),
+])
+
+const { value: illustrationAttribute, reset, modified } = resettableRef(localSettings.illustrationAttribute)
+const editableAttribute = computed({
+  get: () => illustrationAttribute.value ?? AUTO_DETECT,
+  set: (value: string) => (illustrationAttribute.value = AUTO_DETECT === value ? null : value),
+})
+
+const submit = async () => {
+  localSettings.illustrationAttribute = toRaw(illustrationAttribute.value)
+  reset(toRaw(illustrationAttribute.value))
+}
+</script>
+
+<i18n>
+en:
+  labels:
+    illustrationAttribute: Attribute used as the document illustration
+    autoDetect: Auto-detect (default)
+  help:
+    illustrationAttribute: By default, the illustration shown on document cards is guessed from the first
+      attribute that looks like an image URL. Pick an attribute here to always use it instead.
+</i18n>

--- a/app/components/settings/AttributesAsNameEditor.vue
+++ b/app/components/settings/AttributesAsNameEditor.vue
@@ -1,0 +1,63 @@
+<template>
+  <form class="space-y-4" @reset.prevent="reset()" @submit.prevent="submit()">
+    <UFormField :label="t('labels.nameAttribute')" :help="t('help.nameAttribute')">
+      <USelect v-model="editableAttribute" :items="attributeItems" class="w-full sm:w-80" />
+    </UFormField>
+    <footer class="flex flex-col items-center justify-end sm:flex-row">
+      <Buttons>
+        <Button type="reset" :disabled="!modified" />
+        <Button type="submit" :disabled="!modified" />
+      </Buttons>
+    </footer>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { useIndexLocalSettings } from '~/composables'
+import { resettableRef } from '~/utils'
+import Button from '~/components/layout/forms/Button.vue'
+import Buttons from '~/components/layout/forms/Buttons.vue'
+
+type Props = {
+  indexUid: string
+  fields: Array<string>
+}
+const props = defineProps<Props>()
+const { t } = useI18n()
+const localSettings = reactive(useIndexLocalSettings(props.indexUid))
+
+// `USelect` reserves the empty string for "no selection", so auto-detect needs its own sentinel.
+const AUTO_DETECT = '__auto__'
+
+// A previously chosen attribute may no longer exist on this index's documents (removed, renamed) —
+// silently fall back to auto-detect rather than keep pointing at a field that isn't there anymore.
+if (localSettings.nameAttribute && !props.fields.includes(localSettings.nameAttribute)) {
+  localSettings.nameAttribute = null
+}
+
+const attributeItems = computed(() => [
+  { label: t('labels.autoDetect'), value: AUTO_DETECT },
+  ...props.fields.map((field) => ({ label: field, value: field })),
+])
+
+const { value: nameAttribute, reset, modified } = resettableRef(localSettings.nameAttribute)
+const editableAttribute = computed({
+  get: () => nameAttribute.value ?? AUTO_DETECT,
+  set: (value: string) => (nameAttribute.value = AUTO_DETECT === value ? null : value),
+})
+
+const submit = async () => {
+  localSettings.nameAttribute = toRaw(nameAttribute.value)
+  reset(toRaw(nameAttribute.value))
+}
+</script>
+
+<i18n>
+en:
+  labels:
+    nameAttribute: Attribute used as the document name
+    autoDetect: Auto-detect (default)
+  help:
+    nameAttribute: By default, the name shown for a document is guessed from a `name`, `title`, `label` or
+      `id` attribute, in that order. Pick an attribute here to always use it instead.
+</i18n>

--- a/app/composables/useFields.ts
+++ b/app/composables/useFields.ts
@@ -1,5 +1,6 @@
 import match from 'match-operator'
 import type { ComputedRef, MaybeRef } from 'vue'
+import { useIndexLocalSettings } from './useIndexLocalSettings'
 
 type UseFieldsReturn = {
   fields: ComputedRef<Array<string>>
@@ -7,18 +8,27 @@ type UseFieldsReturn = {
   nameField: ComputedRef<string>
 }
 
-export const useFields = (primaryKey: MaybeRef<string>, fields: MaybeRef<Array<string>>): UseFieldsReturn => {
+export const useFields = (
+  primaryKey: MaybeRef<string>,
+  fields: MaybeRef<Array<string>>,
+  indexUid?: string,
+): UseFieldsReturn => {
+  // Falls back to auto-detection whenever the override is unset, or no longer among this
+  // document's fields (attribute removed from the index, or simply absent on this document).
+  const nameAttribute = indexUid ? useIndexLocalSettings(indexUid).nameAttribute : computed(() => null)
   const self: any = reactive({
     primaryKey,
     fields,
     nameField: computed(() =>
-      match(true, [
-        [self.fields.includes('name'), 'name'],
-        [self.fields.includes('title'), 'title'],
-        [self.fields.includes('label'), 'label'],
-        [self.fields.includes('id'), 'id'],
-        [match.default, self.primaryKey],
-      ]),
+      nameAttribute.value && self.fields.includes(nameAttribute.value)
+        ? nameAttribute.value
+        : match(true, [
+            [self.fields.includes('name'), 'name'],
+            [self.fields.includes('title'), 'title'],
+            [self.fields.includes('label'), 'label'],
+            [self.fields.includes('id'), 'id'],
+            [match.default, self.primaryKey],
+          ]),
     ),
     sortedFields: computed(() => [
       self.primaryKey,

--- a/app/composables/useIndexLocalSettings.ts
+++ b/app/composables/useIndexLocalSettings.ts
@@ -13,6 +13,7 @@ type UseIndexLocalSettings = {
   viewMode: ViewMode
   updateMode: UpdateMode
   searchSettings: SearchSettings
+  illustrationAttribute: string | null
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -31,6 +32,7 @@ export const useIndexLocalSettings = (indexUid: string) => {
     viewMode: DEFAULT_VIEW_MODE,
     updateMode: DEFAULT_UPDATE_MODE,
     searchSettings: DEFAULT_SEARCH_SETTINGS,
+    illustrationAttribute: null,
   })
 
   const self = reactive({ storage })
@@ -70,6 +72,10 @@ export const useIndexLocalSettings = (indexUid: string) => {
     searchSettings: computed({
       get: () => ({ ...DEFAULT_SEARCH_SETTINGS, ...(self.storage.searchSettings ?? {}) }),
       set: (value: SearchSettings) => (self.storage.searchSettings = value),
+    }),
+    illustrationAttribute: computed({
+      get: () => self.storage.illustrationAttribute ?? null,
+      set: (value: string | null) => (self.storage.illustrationAttribute = value),
     }),
   }
 }

--- a/app/composables/useIndexLocalSettings.ts
+++ b/app/composables/useIndexLocalSettings.ts
@@ -14,6 +14,7 @@ type UseIndexLocalSettings = {
   updateMode: UpdateMode
   searchSettings: SearchSettings
   illustrationAttribute: string | null
+  nameAttribute: string | null
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -33,6 +34,7 @@ export const useIndexLocalSettings = (indexUid: string) => {
     updateMode: DEFAULT_UPDATE_MODE,
     searchSettings: DEFAULT_SEARCH_SETTINGS,
     illustrationAttribute: null,
+    nameAttribute: null,
   })
 
   const self = reactive({ storage })
@@ -76,6 +78,10 @@ export const useIndexLocalSettings = (indexUid: string) => {
     illustrationAttribute: computed({
       get: () => self.storage.illustrationAttribute ?? null,
       set: (value: string | null) => (self.storage.illustrationAttribute = value),
+    }),
+    nameAttribute: computed({
+      get: () => self.storage.nameAttribute ?? null,
+      set: (value: string | null) => (self.storage.nameAttribute = value),
     }),
   }
 }

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -192,6 +192,14 @@ const facetSearchableAttributes = getFacetSearchableAttributePatterns(rawFiltera
 const { fields } = useFields(primaryKey, Object.keys(stats.fieldDistribution))
 const { appliedSort, facets, itemsPerPage, viewMode, searchSettings } = useIndexLocalSettings(index.uid)
 const appliedFilters = reactive(new AppliedFilters()) as AppliedFilters
+
+// Facets/sort stored while connected to this index may no longer be filterable/sortable (removed
+// from the index settings since last visit) — reconcile against the live lists *before* they can
+// ever be sent to Meilisearch, which would otherwise reject the search and break the page.
+const validFacets = facets.value.filter((facet) => filterableAttributes.includes(facet))
+if (validFacets.length !== facets.value.length) facets.value = validFacets
+const validSort = appliedSort.value.filter((sort) => sortableAttributes.includes(sort.replace(/:(asc|desc)$/, '')))
+if (validSort.length !== appliedSort.value.length) appliedSort.value = validSort
 const searchTerms = ref('')
 const { offset, totalItems, currentPage, previousPage, nextPage, lastPage } = usePagination(itemsPerPage)
 

--- a/app/pages/indexes/[indexUid]/documents/index.vue
+++ b/app/pages/indexes/[indexUid]/documents/index.vue
@@ -189,7 +189,7 @@ const [primaryKey, rawFilterableAttributes, sortableAttributes, searchableAttrib
 const filterableAttributes = getFilterableAttributePatterns(rawFilterableAttributes)
 const facetSearchableAttributes = getFacetSearchableAttributePatterns(rawFilterableAttributes)
 
-const { fields } = useFields(primaryKey, Object.keys(stats.fieldDistribution))
+const { fields } = useFields(primaryKey, Object.keys(stats.fieldDistribution), index.uid)
 const { appliedSort, facets, itemsPerPage, viewMode, searchSettings } = useIndexLocalSettings(index.uid)
 const appliedFilters = reactive(new AppliedFilters()) as AppliedFilters
 

--- a/app/pages/indexes/[indexUid]/settings/local-settings.vue
+++ b/app/pages/indexes/[indexUid]/settings/local-settings.vue
@@ -6,18 +6,25 @@
 
     <AttributesAsDateTimeEditor :index-uid="indexUid" />
     <AttributesAsBadgesEditor :index-uid="indexUid" />
+    <AttributesAsIllustrationEditor :index-uid="indexUid" :fields="fields" />
   </section>
 </template>
 
 <script setup lang="ts">
 import AttributesAsDateTimeEditor from '~/components/settings/AttributesAsDateTimeEditor.vue'
 import AttributesAsBadgesEditor from '~/components/settings/AttributesAsBadgesEditor.vue'
+import AttributesAsIllustrationEditor from '~/components/settings/AttributesAsIllustrationEditor.vue'
+import { useMeiliClient } from '~/composables'
+import { tryOrThrow } from '~/utils'
 
 type Props = {
   indexUid: string
 }
 const props = defineProps<Props>()
 const { t } = useI18n()
+const meili = useMeiliClient()
+const stats = await tryOrThrow(() => meili.index(props.indexUid).getStats())
+const fields = Object.keys(stats.fieldDistribution)
 
 useHead({
   title: `${t('title')} - ${props.indexUid}`,

--- a/app/pages/indexes/[indexUid]/settings/local-settings.vue
+++ b/app/pages/indexes/[indexUid]/settings/local-settings.vue
@@ -6,6 +6,7 @@
 
     <AttributesAsDateTimeEditor :index-uid="indexUid" />
     <AttributesAsBadgesEditor :index-uid="indexUid" />
+    <AttributesAsNameEditor :index-uid="indexUid" :fields="fields" />
     <AttributesAsIllustrationEditor :index-uid="indexUid" :fields="fields" />
   </section>
 </template>
@@ -13,6 +14,7 @@
 <script setup lang="ts">
 import AttributesAsDateTimeEditor from '~/components/settings/AttributesAsDateTimeEditor.vue'
 import AttributesAsBadgesEditor from '~/components/settings/AttributesAsBadgesEditor.vue'
+import AttributesAsNameEditor from '~/components/settings/AttributesAsNameEditor.vue'
 import AttributesAsIllustrationEditor from '~/components/settings/AttributesAsIllustrationEditor.vue'
 import { useMeiliClient } from '~/composables'
 import { tryOrThrow } from '~/utils'


### PR DESCRIPTION
## Summary
- Fixes a crash: `facets`/`appliedSort` stored per-index in localStorage could reference an attribute removed from `filterableAttributes`/`sortableAttributes` since the last visit, sending an invalid search straight to Meilisearch and breaking the Documents page. Both are now reconciled against the live attribute lists as soon as they're fetched, mirroring the existing hybrid-embedder reconciliation already in that file.
- Adds a per-index override for the document card illustration attribute (Local Settings tab): a select populated with the index's real document fields, falling back to the existing auto-detection (first value that looks like an image URL) when unset, and silently resetting to auto-detect if the stored attribute no longer exists on the index.
- Adds the same override for the document *name* attribute (used on cards and map popups, normally guessed from `name`/`title`/`label`/`id` via `useFields`): a Local Settings select, with the fallback to auto-detection now built into `useFields` itself so it degrades gracefully per-document, plus the same silent reset in the editor if the stored attribute no longer exists on the index.

## Test plan
- [x] `yarn run check` (eslint) passes
- [x] `yarn lint` (prettier) passes after `yarn format`
- [x] Manually verified against a local Meilisearch instance seeded with the `movies` dataset:
  - Stale `facets`/`appliedSort` referencing removed attributes no longer crash the Documents page or the filter panel; they're silently pruned from localStorage.
  - The new Local Settings selects list the index's real fields and correctly override the card illustration and the document name.
  - Setting either override to a non-existent attribute in localStorage and reloading silently resets it to auto-detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)