### PR TITLE
Fix: use a toggle for disableOnNumbers in typo tolerance settings

### DIFF
--- a/app/pages/indexes/[indexUid]/settings/typo-tolerance.vue
+++ b/app/pages/indexes/[indexUid]/settings/typo-tolerance.vue
@@ -53,9 +53,15 @@
       <SplitLinesTextarea v-model="typoTolerance!.disableOnAttributes!" class="h-20 w-full text-sm" />
     </UniqueId>
 
-    <UniqueId v-if="satisfiesVersion('^1.15')" v-slot="{ id }" as="div" class="col-span-8">
-      <Label :for="id">{{ t('labels.disableOnNumbers') }}</Label>
-      <SplitLinesTextarea v-model="typoTolerance!.disableOnNumbers!" class="h-20 w-full text-sm" />
+    <UniqueId
+      v-if="satisfiesVersion('^1.15')"
+      as="section"
+      v-slot="{ id }"
+      class="flex items-center justify-between gap-2">
+      <Label :for="id" class="flex items-center gap-2">
+        <span>{{ t('labels.disableOnNumbers') }}</span>
+      </Label>
+      <USwitch :id="id" v-model="typoTolerance!.disableOnNumbers" />
     </UniqueId>
 
     <footer class="flex flex-col items-center justify-between sm:flex-row">


### PR DESCRIPTION
## Summary
- `disableOnNumbers` is a `boolean` in the Meilisearch API (v1.15+), not an array like `disableOnWords`/`disableOnAttributes` — the settings page was wrongly rendering it with `SplitLinesTextarea`.
- Replaced with a `USwitch`, matching the layout already used for the "Enable Typo Tolerance" toggle on the same page.

## Test plan
- [x] `yarn lint` (Prettier) / `yarn run check` (ESLint) pass
- [x] Manually verified against a local Meilisearch 1.53.1 instance: toggled the switch, submitted, confirmed `GET /indexes/:uid/settings/typo-tolerance` returns `"disableOnNumbers":true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)